### PR TITLE
[codex] Add multi-account round-robin support

### DIFF
--- a/bin/modelrelay.js
+++ b/bin/modelrelay.js
@@ -22,10 +22,17 @@ function printHelp() {
   console.log('  modelrelay start --autostart')
   console.log('  modelrelay uninstall --autostart')
   console.log('  modelrelay status --autostart')
+  console.log('  modelrelay status')
   console.log('  modelrelay update')
   console.log('  modelrelay refresh-scores')
   console.log('  modelrelay config export')
   console.log('  modelrelay config import <token>')
+  console.log('  modelrelay config set-keys <provider> <key1,key2,...>')
+  console.log('  modelrelay config add-key <provider> <key>')
+  console.log('  modelrelay config remove-key <provider> <key>')
+  console.log('  modelrelay config remove-key <provider> <index>')
+  console.log('  modelrelay config set-maxturns <provider> <number>')
+  console.log('  modelrelay config set-maxturns <provider> 0')
   console.log('  modelrelay autoupdate [--enable|--disable|--status] [--interval <hours>]')
   console.log('  modelrelay autostart [--install|--start|--uninstall|--status]')
   console.log('')
@@ -223,8 +230,201 @@ async function main() {
       return
     }
 
+    if (cliArgs.configAction === 'set-keys') {
+      const provider = cliArgs.configProvider
+      const keysRaw = cliArgs.configKeys
+      if (!provider || !keysRaw) {
+        console.error('Usage: modelrelay config set-keys <provider> <key1,key2,...>')
+        process.exit(1)
+      }
+      const keys = keysRaw.split(',').map(k => k.trim()).filter(Boolean)
+      if (keys.length === 0) {
+        console.error('No valid keys provided.')
+        process.exit(1)
+      }
+      const config = loadConfig()
+      if (!config.apiKeys) config.apiKeys = {}
+      config.apiKeys[provider] = keys.length === 1 ? keys[0] : keys
+      saveConfig(config)
+      if (keys.length === 1) {
+        console.log(chalk.green(`✔ Set key for ${provider}: ${keys[0].slice(0, 4)}...`))
+      } else {
+        console.log(chalk.green(`✔ Set ${keys.length} keys for ${provider}`))
+        keys.forEach((k, i) => console.log(chalk.dim(`  [${i}] ${k.slice(0, 4)}...`)))
+      }
+      return
+    }
+
+    if (cliArgs.configAction === 'add-key') {
+      const provider = cliArgs.configProvider
+      const key = cliArgs.configKeys
+      if (!provider || !key) {
+        console.error('Usage: modelrelay config add-key <provider> <key>')
+        process.exit(1)
+      }
+      const config = loadConfig()
+      if (!config.apiKeys) config.apiKeys = {}
+      const existing = config.apiKeys[provider]
+      if (Array.isArray(existing)) {
+        if (existing.includes(key)) {
+          console.log(chalk.yellow(`Key already exists in pool for ${provider}.`))
+        } else {
+          existing.push(key)
+          config.apiKeys[provider] = existing
+          saveConfig(config)
+          console.log(chalk.green(`✔ Added key to ${provider} (now ${existing.length} keys)`))
+        }
+      } else if (typeof existing === 'string' && existing) {
+        config.apiKeys[provider] = [existing, key]
+        saveConfig(config)
+        console.log(chalk.green(`✔ Added second key to ${provider} (now 2 keys, round-robin enabled)`))
+      } else {
+        config.apiKeys[provider] = key
+        saveConfig(config)
+        console.log(chalk.green(`✔ Set single key for ${provider}`))
+      }
+      return
+    }
+
+    if (cliArgs.configAction === 'remove-key') {
+      const provider = cliArgs.configProvider
+      const keyOrIndex = cliArgs.configKeys
+      if (!provider || keyOrIndex === undefined) {
+        console.error('Usage: modelrelay config remove-key <provider> <key|index>')
+        process.exit(1)
+      }
+      const config = loadConfig()
+      if (!config.apiKeys || !config.apiKeys[provider]) {
+        console.error(`No keys configured for provider ${provider}.`)
+        process.exit(1)
+      }
+      const existing = config.apiKeys[provider]
+      if (!Array.isArray(existing)) {
+        delete config.apiKeys[provider]
+        saveConfig(config)
+        console.log(chalk.green(`✔ Removed single key for ${provider}.`))
+        return
+      }
+      const idx = Number(keyOrIndex)
+      if (!isNaN(idx) && idx >= 0 && idx < existing.length) {
+        const removed = existing.splice(idx, 1)[0]
+        if (existing.length === 0) {
+          delete config.apiKeys[provider]
+        } else if (existing.length === 1) {
+          config.apiKeys[provider] = existing[0]
+        } else {
+          config.apiKeys[provider] = existing
+        }
+        saveConfig(config)
+        console.log(chalk.green(`✔ Removed key [${idx}] ${removed.slice(0, 4)}... from ${provider} (${existing.length} remaining)`))
+      } else {
+        const idx2 = existing.indexOf(keyOrIndex)
+        if (idx2 !== -1) {
+          existing.splice(idx2, 1)
+          if (existing.length === 0) {
+            delete config.apiKeys[provider]
+          } else if (existing.length === 1) {
+            config.apiKeys[provider] = existing[0]
+          } else {
+            config.apiKeys[provider] = existing
+          }
+          saveConfig(config)
+          console.log(chalk.green(`✔ Removed key ${keyOrIndex.slice(0, 4)}... from ${provider} (${existing.length} remaining)`))
+        } else {
+          console.error(`Key not found in ${provider} pool: ${keyOrIndex}`)
+          process.exit(1)
+        }
+      }
+      return
+    }
+
+    if (cliArgs.configAction === 'set-maxturns') {
+      const provider = cliArgs.configProvider
+      const val = cliArgs.configMaxTurns
+      if (!provider || val === undefined) {
+        console.error('Usage: modelrelay config set-maxturns <provider> <number>')
+        process.exit(1)
+      }
+      const maxTurns = Math.floor(Number(val))
+      if (isNaN(maxTurns)) {
+        console.error('maxTurns must be a number.')
+        process.exit(1)
+      }
+      const config = loadConfig()
+      if (!config.providers) config.providers = {}
+      if (!config.providers[provider]) config.providers[provider] = {}
+      if (maxTurns === 0) {
+        delete config.providers[provider].maxTurns
+        saveConfig(config)
+        console.log(chalk.green(`✔ maxTurns disabled for ${provider} (unlimited requests per account)`))
+      } else {
+        config.providers[provider].maxTurns = maxTurns
+        saveConfig(config)
+        console.log(chalk.green(`✔ maxTurns set to ${maxTurns} for ${provider}`))
+      }
+      return
+    }
+
     console.error('Usage: modelrelay config export | modelrelay config import <token>')
+    console.error('       modelrelay config set-keys <provider> <key1,key2,...>')
+    console.error('       modelrelay config add-key <provider> <key>')
+    console.error('       modelrelay config remove-key <provider> <key|index>')
+    console.error('       modelrelay config set-maxturns <provider> <number>')
     process.exit(1)
+  }
+
+  if (cliArgs.command === 'status') {
+    const config = loadConfig()
+    const { getAccountStatus } = await import('../lib/server.js')
+    const { sources } = await import('../sources.js')
+    const { getApiKeyPool, getMaxTurns } = await import('../lib/config.js')
+
+    const liveStatus = getAccountStatus(config)
+
+    console.log()
+    console.log(chalk.bold('modelrelay account status'))
+    console.log()
+
+    const configuredProviders = Object.keys(config.apiKeys || {}).filter(k => getApiKeyPool(config, k).length > 0)
+
+    if (configuredProviders.length === 0) {
+      console.log(chalk.dim('No accounts configured.'))
+      console.log(chalk.dim('Add keys: modelrelay config add-key <provider> <key>'))
+      return
+    }
+
+    for (const provider of configuredProviders) {
+      const info = sources[provider]
+      const name = info?.name || provider
+      const isEnabled = config?.providers?.[provider]?.enabled !== false
+      const maxTurns = getMaxTurns(config, provider)
+      const pool = getApiKeyPool(config, provider)
+      const live = liveStatus.providers[provider]
+
+      console.log(chalk.bold(`${name} (${provider})`) + chalk.dim(` ${isEnabled ? 'enabled' : 'disabled'} | ${pool.length} account${pool.length !== 1 ? 's' : ''} | maxTurns: ${maxTurns > 0 ? maxTurns : 'unlimited'}`))
+
+      for (let i = 0; i < pool.length; i++) {
+        const key = pool[i]
+        const masked = key.length > 8 ? `${key.slice(0, 4)}...${key.slice(-4)}` : `${key.slice(0, 2)}***`
+        const liveAcct = live?.accounts?.find(a => a.index === i)
+        const requests = liveAcct?.requests ?? 0
+        const isRateLimited = liveAcct?.rateLimited ?? false
+        const hitMaxTurns = maxTurns > 0 && requests >= maxTurns
+
+        let statusIcon = chalk.green('🟢')
+        if (isRateLimited) statusIcon = chalk.red('🔴')
+        else if (hitMaxTurns) statusIcon = chalk.yellow('🟡')
+
+        const rotation = live?.currentIdx === i ? ' ← next' : ''
+        console.log(`  ${statusIcon} [${i}] ${masked}${rotation}  requests: ${requests}`)
+      }
+      console.log()
+    }
+
+    if (configuredProviders.length > 0) {
+      console.log(chalk.dim('(Live request counts require the router to be running)'))
+    }
+    return
   }
 
   if (cliArgs.onboard) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -33,12 +33,18 @@
  *     }
  *   }
  *
+ * 📖 Multi-account round-robin:
+ *   apiKeys values can be string | string[].
+ *   Array = multiple accounts, rotated per-request with max-turns + 429 backoff.
+ *
  * @functions
  *   → loadConfig() — Read ~/.modelrelay.json
  *   → saveConfig(config) — Write config to ~/.modelrelay.json with 0o600 permissions
- *   → getApiKey(config, providerKey) — Get effective API key (env var override > config > null)
+ *   → getApiKey(config, providerKey) — Get first API key (backward-compatible)
+ *   → getApiKeyPool(config, providerKey) — Get all API keys as array
+ *   → hasMultipleKeys(config, providerKey) — Whether provider has multiple accounts
  *
- * @exports loadConfig, saveConfig, getApiKey
+ * @exports loadConfig, saveConfig, getApiKey, getApiKeyPool, hasMultipleKeys
  * @exports CONFIG_PATH — path to the JSON config file
  *
  * @see bin/modelrelay.js — main CLI that uses these functions
@@ -178,13 +184,60 @@ export function getApiKey(config, providerKey) {
     return normalizeSecret(process.env.DASHSCOPE_API_KEY);
   }
 
-  // 📖 Config file value
+  // 📖 Config file value (string or array — return first element)
   const key = config?.apiKeys?.[providerKey]
-  if (key) {
-    return normalizeSecret(key);
-  }
-
+  if (Array.isArray(key)) return normalizeSecret(key[0]) || null
+  if (key) return normalizeSecret(key)
   return null
+}
+
+/**
+ * 📖 getApiKeyPool: Get all configured API keys for a provider.
+ * Returns an array of keys. Env var override returns single-element array.
+ * @param {object} config
+ * @param {string} providerKey
+ * @returns {string[]}
+ */
+export function getApiKeyPool(config, providerKey) {
+  const envVar = ENV_VARS[providerKey]
+  if (envVar && process.env[envVar]) {
+    const k = normalizeSecret(process.env[envVar])
+    return k ? [k] : []
+  }
+  if (providerKey === 'qwencode' && process.env.DASHSCOPE_API_KEY) {
+    const k = normalizeSecret(process.env.DASHSCOPE_API_KEY)
+    return k ? [k] : []
+  }
+  const raw = config?.apiKeys?.[providerKey]
+  if (Array.isArray(raw)) return raw.map(normalizeSecret).filter(Boolean)
+  if (typeof raw === 'string' && raw.trim()) return [normalizeSecret(raw)]
+  return []
+}
+
+/**
+ * 📖 hasMultipleKeys: Check if a provider has multiple API key accounts.
+ * @param {object} config
+ * @param {string} providerKey
+ * @returns {boolean}
+ */
+export function hasMultipleKeys(config, providerKey) {
+  return getApiKeyPool(config, providerKey).length > 1
+}
+
+/**
+ * 📖 getMaxTurns: Get the per-account max-turns threshold for a provider.
+ * When an account reaches this many requests, rotate to the next one
+ * (proactive switching before hitting rate limits).
+ * @param {object} config
+ * @param {string} providerKey
+ * @returns {number} 0 = no limit
+ */
+export function getMaxTurns(config, providerKey) {
+  const providerConfig = config?.providers?.[providerKey]
+  if (!providerConfig) return 0
+  const val = Number(providerConfig.maxTurns)
+  if (!Number.isFinite(val) || val < 1) return 0
+  return Math.floor(val)
 }
 
 export function getProviderBaseUrl(config, providerKey) {
@@ -303,8 +356,11 @@ export function normalizeConfigShape(config) {
 
   // Trim API key strings to avoid copy/paste artifacts.
   for (const provider in base.apiKeys) {
-    if (typeof base.apiKeys[provider] === 'string') {
-      base.apiKeys[provider] = normalizeSecret(base.apiKeys[provider])
+    const val = base.apiKeys[provider]
+    if (Array.isArray(val)) {
+      base.apiKeys[provider] = val.map(normalizeSecret).filter(Boolean)
+    } else if (typeof val === 'string') {
+      base.apiKeys[provider] = normalizeSecret(val)
     }
   }
 

--- a/lib/onboard.js
+++ b/lib/onboard.js
@@ -5,7 +5,7 @@ import { join, dirname } from 'node:path'
 import { homedir } from 'node:os'
 import { sources } from '../sources.js'
 import { API_KEY_SIGNUP_URLS } from './providerLinks.js'
-import { loadConfig, saveConfig } from './config.js'
+import { loadConfig, saveConfig, getApiKeyPool, getMaxTurns } from './config.js'
 import { installAutostart } from './autostart.js'
 
 const PROVIDER_ORDER = [
@@ -296,6 +296,47 @@ export async function runOnboard(port = 7352) {
 
   saveConfig(config)
   console.log('Saved API keys to ~/.modelrelay.json')
+
+  const multiAccountProviders = []
+  for (const providerKey of PROVIDER_ORDER) {
+    if (!sources[providerKey]) continue
+    const pool = getApiKeyPool(config, providerKey)
+    if (pool.length > 1) {
+      multiAccountProviders.push({ key: providerKey, name: sources[providerKey].name, count: pool.length })
+    }
+  }
+
+  if (multiAccountProviders.length > 0) {
+    console.log('\n--- Multi-Account Round-Robin ---')
+    for (const { name, key, count } of multiAccountProviders) {
+      console.log(`${name}: ${count} accounts configured. Requests will rotate across accounts.`)
+    }
+    console.log('Round-robin switches accounts to avoid hitting per-account rate limits.')
+    const maxTurnsAnswer = await rl.question(`\nSet max-turns threshold (per-account)? Press Enter for unlimited (0), or enter a number (e.g. 20): `)
+    const maxTurnsVal = maxTurnsAnswer.trim() || '0'
+    const maxTurnsNum = Math.floor(Number(maxTurnsVal))
+    for (const { key } of multiAccountProviders) {
+      if (!config.providers[key]) config.providers[key] = {}
+      if (isNaN(maxTurnsNum) || maxTurnsNum <= 0) {
+        delete config.providers[key].maxTurns
+      } else {
+        config.providers[key].maxTurns = maxTurnsNum
+      }
+    }
+    if (!isNaN(maxTurnsNum) && maxTurnsNum > 0) {
+      console.log(`max-turns set to ${maxTurnsNum} for multi-account providers.`)
+    } else {
+      console.log('max-turns disabled (unlimited).')
+    }
+    saveConfig(config)
+  } else {
+    const hasSingleKeys = Object.keys(config.apiKeys || {}).some(k => getApiKeyPool(config, k).length === 1)
+    if (hasSingleKeys) {
+      console.log('\nTip: Add multiple API keys for automatic round-robin to avoid rate limits:')
+      console.log('  modelrelay config add-key <provider> <key2>')
+      console.log('  modelrelay config set-maxturns <provider> 20')
+    }
+  }
 
   const openCodeAnswer = await rl.question('\nAuto-configure OpenCode now? [Y/n]: ')
   const doOpenCode = parseYesNo(openCodeAnswer, true)

--- a/lib/server.js
+++ b/lib/server.js
@@ -7,7 +7,7 @@ import { homedir } from 'os';
 import { MODELS, sources, canonicalizeModelId, getPreferredModelLabel, getScore, resolveAliasedModelId } from '../sources.js';
 import { API_KEY_SIGNUP_URLS } from './providerLinks.js';
 import { getApiKey, getApiKeyPool, getMaxTurns, getPinningMode, getProviderBaseUrl, getProviderModelId, hasMultipleKeys, isProviderEnabled, getProviderPingIntervalMs, loadConfig, saveConfig, exportConfigToken, importConfigToken } from './config.js';
-import { buildModelGroups, computeQoSMap, findBestModel, getAvg, getUptime, getVerdict, isRetryableProxyStatus, rankModelsForRouting, parseOpenRouterKeyRateLimit, filterModelsByRequested } from './utils.js';
+import { buildModelGroups, computeQoSMap, findBestModel, getAvg, getUptime, getVerdict, isRetryableProxyStatus, rankModelsForRouting, parseOpenRouterKeyRateLimit, filterModelsByRequested, selectNextApiKeyFromPool } from './utils.js';
 import { getPreferredLanIpv4Address } from './network.js';
 import { createHash, randomUUID } from 'crypto';
 import { hasQwenOauthCredentials, pollQwenOauthDeviceToken, resolveQwenCodeOauthSession, startQwenOauthDeviceLogin } from './qwencodeAuth.js';
@@ -946,31 +946,7 @@ export async function runServer(config, port, enableLog = true, bannedModels = [
     const entry = getKeyPoolEntry(providerKey)
     const maxTurns = getMaxTurns(config, providerKey)
     const now = Date.now()
-
-    // Try up to pool.length times to find an available account
-    for (let attempt = 0; attempt < pool.length; attempt++) {
-      const idx = entry.currentIdx % pool.length
-      const acct = entry.accounts.get(idx)
-      const isRateLimited = acct && acct.rateLimitedAt && (now - acct.rateLimitedAt) < KEY_POOL_COOLDOWN_MS
-      const hitMaxTurns = maxTurns > 0 && acct && acct.requests >= maxTurns
-
-      if (!isRateLimited && !hitMaxTurns) {
-        if (!entry.accounts.has(idx)) entry.accounts.set(idx, { requests: 0, rateLimitedAt: 0 })
-        entry.accounts.get(idx).requests++
-        entry.currentIdx = (idx + 1) % pool.length
-        return pool[idx]
-      }
-      entry.currentIdx = (idx + 1) % pool.length
-    }
-
-    // All accounts exhausted — reset and use first available
-    for (const [, acct] of entry.accounts) acct.requests = 0
-    entry.currentIdx = 0
-    const idx = 0
-    if (!entry.accounts.has(idx)) entry.accounts.set(idx, { requests: 0, rateLimitedAt: 0 })
-    entry.accounts.get(idx).requests++
-    entry.currentIdx = 1 % pool.length
-    return pool[idx]
+    return selectNextApiKeyFromPool(pool, entry, maxTurns, now, KEY_POOL_COOLDOWN_MS)
   }
 
   function markRateLimited(providerKey, apiKey) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -6,7 +6,7 @@ import { readFileSync, writeFileSync, existsSync } from 'fs';
 import { homedir } from 'os';
 import { MODELS, sources, canonicalizeModelId, getPreferredModelLabel, getScore, resolveAliasedModelId } from '../sources.js';
 import { API_KEY_SIGNUP_URLS } from './providerLinks.js';
-import { getApiKey, getPinningMode, getProviderBaseUrl, getProviderModelId, isProviderEnabled, getProviderPingIntervalMs, loadConfig, saveConfig, exportConfigToken, importConfigToken } from './config.js';
+import { getApiKey, getApiKeyPool, getMaxTurns, getPinningMode, getProviderBaseUrl, getProviderModelId, hasMultipleKeys, isProviderEnabled, getProviderPingIntervalMs, loadConfig, saveConfig, exportConfigToken, importConfigToken } from './config.js';
 import { buildModelGroups, computeQoSMap, findBestModel, getAvg, getUptime, getVerdict, isRetryableProxyStatus, rankModelsForRouting, parseOpenRouterKeyRateLimit, filterModelsByRequested } from './utils.js';
 import { getPreferredLanIpv4Address } from './network.js';
 import { createHash, randomUUID } from 'crypto';
@@ -892,6 +892,61 @@ export async function runServer(config, port, enableLog = true, bannedModels = [
   // 📖 pinnedModelId: when set, ALL proxy requests are locked to this model (in-memory, resets on restart)
   let pinnedModelId = null;
   let pinnedProviderKey = null;
+
+  // Multi-account round-robin state
+  const KEY_POOL_COOLDOWN_MS = 60_000
+  const keyPoolState = new Map() // providerKey → { currentIdx, accounts: Map<idx, { requests, rateLimitedAt }> }
+
+  function getKeyPoolEntry(providerKey) {
+    if (!keyPoolState.has(providerKey)) {
+      keyPoolState.set(providerKey, { currentIdx: 0, accounts: new Map() })
+    }
+    return keyPoolState.get(providerKey)
+  }
+
+  function getNextApiKey(config, providerKey) {
+    const pool = getApiKeyPool(config, providerKey)
+    if (pool.length === 0) return null
+    if (pool.length === 1) return pool[0]
+
+    const entry = getKeyPoolEntry(providerKey)
+    const maxTurns = getMaxTurns(config, providerKey)
+    const now = Date.now()
+
+    // Try up to pool.length times to find an available account
+    for (let attempt = 0; attempt < pool.length; attempt++) {
+      const idx = entry.currentIdx % pool.length
+      const acct = entry.accounts.get(idx)
+      const isRateLimited = acct && acct.rateLimitedAt && (now - acct.rateLimitedAt) < KEY_POOL_COOLDOWN_MS
+      const hitMaxTurns = maxTurns > 0 && acct && acct.requests >= maxTurns
+
+      if (!isRateLimited && !hitMaxTurns) {
+        if (!entry.accounts.has(idx)) entry.accounts.set(idx, { requests: 0, rateLimitedAt: 0 })
+        entry.accounts.get(idx).requests++
+        entry.currentIdx = (idx + 1) % pool.length
+        return pool[idx]
+      }
+      entry.currentIdx = (idx + 1) % pool.length
+    }
+
+    // All accounts exhausted — reset and use first available
+    for (const [, acct] of entry.accounts) acct.requests = 0
+    entry.currentIdx = 0
+    const idx = 0
+    if (!entry.accounts.has(idx)) entry.accounts.set(idx, { requests: 0, rateLimitedAt: 0 })
+    entry.accounts.get(idx).requests++
+    entry.currentIdx = 1 % pool.length
+    return pool[idx]
+  }
+
+  function markRateLimited(providerKey, apiKey) {
+    const pool = getApiKeyPool(loadConfig(), providerKey)
+    const idx = pool.indexOf(apiKey)
+    if (idx === -1) return
+    const entry = getKeyPoolEntry(providerKey)
+    if (!entry.accounts.has(idx)) entry.accounts.set(idx, { requests: 0, rateLimitedAt: 0 })
+    entry.accounts.get(idx).rateLimitedAt = Date.now()
+  }
   const currentConfigLoader = loadConfig();
   if (currentConfigLoader.bannedModels && currentConfigLoader.bannedModels.length > 0) {
     bannedModels = [...new Set([...bannedModels, ...currentConfigLoader.bannedModels])];
@@ -1447,7 +1502,7 @@ export async function runServer(config, port, enableLog = true, bannedModels = [
       key,
       name: sources[key].name,
       enabled: isProviderEnabled(currentConfig, key),
-      hasKey: !!getApiKey(currentConfig, key) || (key === 'qwencode' && hasQwenOauthCredentials()),
+      hasKey: getApiKeyPool(currentConfig, key).length > 0 || (key === 'qwencode' && hasQwenOauthCredentials()),
       signupUrl: API_KEY_SIGNUP_URLS[key] || null,
       supportsOptionalBearerAuth: isProviderAuthOptional(currentConfig, key),
       useBearerAuth: isProviderAuthOptional(currentConfig, key) ? isProviderBearerAuthEnabled(currentConfig, key) : null,
@@ -2087,7 +2142,11 @@ export async function runServer(config, port, enableLog = true, bannedModels = [
         payload.model = best.modelId;
 
         const currentConfig = loadConfig();
-        let providerAuth = await resolveProviderAuthToken(currentConfig, best.providerKey);
+        // Multi-account round-robin: use rotated key if pool configured
+        const rotKey = getNextApiKey(currentConfig, best.providerKey)
+        let providerAuth = rotKey
+          ? { token: rotKey, authSource: 'api-key', providerUrlOverride: null }
+          : await resolveProviderAuthToken(currentConfig, best.providerKey);
         let providerUrl = resolveProviderUrl(currentConfig, best.providerKey, providerAuth.providerUrlOverride, best.providerUrl);
 
         const attemptMeta = {
@@ -2151,7 +2210,7 @@ export async function runServer(config, port, enableLog = true, bannedModels = [
           }
 
           if (shouldRetryOptionalProviderWithBearer(currentConfig, best.providerKey, providerAuth, String(response.status), null)) {
-            const fallbackToken = getApiKey(currentConfig, best.providerKey);
+            const fallbackToken = getNextApiKey(currentConfig, best.providerKey);
             if (fallbackToken) {
               providerAuth = { token: fallbackToken, authSource: 'api-key', providerUrlOverride: providerAuth.providerUrlOverride };
               headers = buildProviderRequestHeaders(best.providerKey, {
@@ -2182,6 +2241,11 @@ export async function runServer(config, port, enableLog = true, bannedModels = [
         attemptMeta.status = String(response.status);
         attemptMeta.retryable = isRetryableProxyStatus(response.status);
         attempts.push(attemptMeta);
+
+        // On 429: mark this account as rate-limited so next retry picks a different key
+        if (response.status === 429 && hasMultipleKeys(currentConfig, best.providerKey)) {
+          markRateLimited(best.providerKey, providerAuth.token)
+        }
 
         await captureProxyRateLimit(best, response, providerAuth.token);
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -75,6 +75,39 @@ const latestVersionCache = {
 
 const qwenOauthLoginSessions = new Map();
 
+let _keyPoolState = null;
+function _setKeyPoolState(state) { _keyPoolState = state; }
+
+export function getAccountStatus(config) {
+  const providers = {}
+  if (!_keyPoolState) return { providers }
+
+  for (const [providerKey, entry] of _keyPoolState) {
+    const pool = getApiKeyPool(config, providerKey)
+    if (pool.length === 0) continue
+    const maxTurns = getMaxTurns(config, providerKey)
+    const now = Date.now()
+    const accounts = pool.map((key, idx) => {
+      const acct = entry.accounts.get(idx)
+      const isRateLimited = acct && acct.rateLimitedAt && (now - acct.rateLimitedAt) < KEY_POOL_COOLDOWN_MS
+      const masked = key.length > 8 ? `${key.slice(0, 4)}...${key.slice(-4)}` : `${key.slice(0, 2)}***`
+      return {
+        index: idx,
+        masked,
+        requests: acct ? acct.requests : 0,
+        rateLimited: !!isRateLimited,
+      }
+    })
+    providers[providerKey] = {
+      keyCount: pool.length,
+      currentIdx: entry.currentIdx % pool.length,
+      maxTurns,
+      accounts,
+    }
+  }
+  return { providers }
+}
+
 export function toPinnedRowKey(result) {
   return `${result?.providerKey || ''}::${result?.modelId || ''}`;
 }
@@ -896,6 +929,7 @@ export async function runServer(config, port, enableLog = true, bannedModels = [
   // Multi-account round-robin state
   const KEY_POOL_COOLDOWN_MS = 60_000
   const keyPoolState = new Map() // providerKey → { currentIdx, accounts: Map<idx, { requests, rateLimitedAt }> }
+  _setKeyPoolState(keyPoolState)
 
   function getKeyPoolEntry(providerKey) {
     if (!keyPoolState.has(providerKey)) {
@@ -1498,18 +1532,28 @@ export async function runServer(config, port, enableLog = true, bannedModels = [
 
   app.get('/api/config', (req, res) => {
     const currentConfig = loadConfig();
-    const providers = Object.keys(sources).map(key => ({
-      key,
-      name: sources[key].name,
-      enabled: isProviderEnabled(currentConfig, key),
-      hasKey: getApiKeyPool(currentConfig, key).length > 0 || (key === 'qwencode' && hasQwenOauthCredentials()),
-      signupUrl: API_KEY_SIGNUP_URLS[key] || null,
-      supportsOptionalBearerAuth: isProviderAuthOptional(currentConfig, key),
-      useBearerAuth: isProviderAuthOptional(currentConfig, key) ? isProviderBearerAuthEnabled(currentConfig, key) : null,
-      pingIntervalMinutes: currentConfig.providers?.[key]?.pingIntervalMinutes || null,
-      baseUrl: (key === OPENAI_COMPATIBLE_PROVIDER_KEY || key === OLLAMA_PROVIDER_KEY) ? (getProviderBaseUrl(currentConfig, key) || '') : null,
-      modelId: (key === OPENAI_COMPATIBLE_PROVIDER_KEY || key === OLLAMA_PROVIDER_KEY) ? (getProviderModelId(currentConfig, key) || '') : null,
-    }));
+    const providers = Object.keys(sources).map(key => {
+      const pool = getApiKeyPool(currentConfig, key)
+      const hasMultiple = pool.length > 1
+      return {
+        key,
+        name: sources[key].name,
+        enabled: isProviderEnabled(currentConfig, key),
+        hasKey: pool.length > 0 || (key === 'qwencode' && hasQwenOauthCredentials()),
+        signupUrl: API_KEY_SIGNUP_URLS[key] || null,
+        supportsOptionalBearerAuth: isProviderAuthOptional(currentConfig, key),
+        useBearerAuth: isProviderAuthOptional(currentConfig, key) ? isProviderBearerAuthEnabled(currentConfig, key) : null,
+        pingIntervalMinutes: currentConfig.providers?.[key]?.pingIntervalMinutes || null,
+        baseUrl: (key === OPENAI_COMPATIBLE_PROVIDER_KEY || key === OLLAMA_PROVIDER_KEY) ? (getProviderBaseUrl(currentConfig, key) || '') : null,
+        modelId: (key === OPENAI_COMPATIBLE_PROVIDER_KEY || key === OLLAMA_PROVIDER_KEY) ? (getProviderModelId(currentConfig, key) || '') : null,
+        hasMultipleKeys: hasMultiple,
+        maxTurns: getMaxTurns(currentConfig, key),
+        apiKeyPool: pool.map((k, i) => {
+          const masked = k.length > 8 ? `${k.slice(0, 4)}...${k.slice(-4)}` : `${k.slice(0, 2)}***`
+          return { index: i, masked, key: k }
+        }),
+      }
+    });
     res.json(providers);
   });
 
@@ -1580,6 +1624,11 @@ export async function runServer(config, port, enableLog = true, bannedModels = [
       importedApiKeys: Object.keys(importedConfig.apiKeys || {}).length,
     });
   });
+
+  app.get('/api/account-status', (req, res) => {
+    const currentConfig = loadConfig()
+    res.json(getAccountStatus(currentConfig))
+  })
 
   app.get('/api/autoupdate', (req, res) => {
     const cfg = loadConfig();
@@ -1672,7 +1721,7 @@ export async function runServer(config, port, enableLog = true, bannedModels = [
   });
 
   app.post('/api/config', (req, res) => {
-    const { providerKey, apiKey, enabled, useBearerAuth, pingIntervalMinutes, baseUrl, modelId, pinningMode } = req.body;
+    const { providerKey, apiKey, enabled, useBearerAuth, pingIntervalMinutes, baseUrl, modelId, pinningMode, maxTurns, apiKeys } = req.body;
     const currentConfig = loadConfig();
     const wasEnabled = isProviderEnabled(currentConfig, providerKey);
 
@@ -1683,6 +1732,18 @@ export async function runServer(config, port, enableLog = true, bannedModels = [
         currentConfig.apiKeys[providerKey] = String(apiKey).trim();
       }
     }
+
+    if (apiKeys !== undefined && Array.isArray(apiKeys)) {
+      const validKeys = apiKeys.filter(k => typeof k === 'string' && k.trim())
+      if (validKeys.length === 0) {
+        delete currentConfig.apiKeys[providerKey];
+      } else if (validKeys.length === 1) {
+        currentConfig.apiKeys[providerKey] = validKeys[0].trim()
+      } else {
+        currentConfig.apiKeys[providerKey] = validKeys.map(k => k.trim())
+      }
+    }
+
     if (enabled !== undefined) {
       if (!currentConfig.providers) currentConfig.providers = {};
       if (!currentConfig.providers[providerKey]) currentConfig.providers[providerKey] = {};
@@ -1719,6 +1780,17 @@ export async function runServer(config, port, enableLog = true, bannedModels = [
         if (Number.isFinite(parsed) && parsed >= 1) {
           currentConfig.providers[providerKey].pingIntervalMinutes = parsed;
         }
+      }
+    }
+
+    if (maxTurns !== undefined) {
+      if (!currentConfig.providers) currentConfig.providers = {};
+      if (!currentConfig.providers[providerKey]) currentConfig.providers[providerKey] = {};
+      const parsed = Math.floor(Number(maxTurns))
+      if (!Number.isFinite(parsed) || parsed <= 0) {
+        delete currentConfig.providers[providerKey].maxTurns
+      } else {
+        currentConfig.providers[providerKey].maxTurns = parsed
       }
     }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -173,6 +173,56 @@ export function findBestModel(results) {
   return ranked[0] || null
 }
 
+function ensureKeyPoolAccount(entry, idx) {
+  if (!entry.accounts.has(idx)) {
+    entry.accounts.set(idx, { requests: 0, rateLimitedAt: 0 })
+  }
+  return entry.accounts.get(idx)
+}
+
+export function selectNextApiKeyFromPool(pool, entry, maxTurns, now, cooldownMs) {
+  if (!Array.isArray(pool) || pool.length === 0) return null
+  if (!entry || !(entry.accounts instanceof Map)) return null
+
+  const isRateLimited = idx => {
+    const acct = entry.accounts.get(idx)
+    return !!(acct && acct.rateLimitedAt && (now - acct.rateLimitedAt) < cooldownMs)
+  }
+
+  const trySelect = (respectMaxTurns) => {
+    for (let attempt = 0; attempt < pool.length; attempt++) {
+      const idx = entry.currentIdx % pool.length
+      const acct = entry.accounts.get(idx)
+      const keyRateLimited = isRateLimited(idx)
+      const hitMaxTurns = respectMaxTurns && maxTurns > 0 && acct && acct.requests >= maxTurns
+
+      if (!keyRateLimited && !hitMaxTurns) {
+        const selectedAccount = ensureKeyPoolAccount(entry, idx)
+        selectedAccount.requests++
+        entry.currentIdx = (idx + 1) % pool.length
+        return pool[idx]
+      }
+
+      entry.currentIdx = (idx + 1) % pool.length
+    }
+
+    return null
+  }
+
+  const selected = trySelect(true)
+  if (selected) return selected
+
+  const hasNonRateLimitedKey = pool.some((_, idx) => !isRateLimited(idx))
+  if (!hasNonRateLimitedKey) return null
+
+  for (const [, acct] of entry.accounts) {
+    acct.requests = 0
+  }
+  entry.currentIdx = 0
+
+  return trySelect(false)
+}
+
 function normalizeModelAlias(value) {
   if (typeof value !== 'string') return ''
   return value.trim().toLowerCase()

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -376,6 +376,9 @@ export function parseArgs(argv) {
 
   let configAction = null
   let configPayload = null
+  let configProvider = null
+  let configKeys = null
+  let configMaxTurns = null
   if (command === 'config') {
     const actionIdx = args.findIndex((a, idx) => idx > 0 && !a.startsWith('--'))
     const action = actionIdx !== -1 ? args[actionIdx].toLowerCase() : null
@@ -385,6 +388,24 @@ export function parseArgs(argv) {
     if (configAction === 'import' && actionIdx !== -1) {
       const payload = args.slice(actionIdx + 1).join(' ').trim()
       if (payload) configPayload = payload
+    }
+    if (action === 'set-keys' || action === 'add-key' || action === 'remove-key') {
+      configAction = action
+      if (args.length > 2) {
+        configProvider = args[2]
+      }
+      if (args.length > 3) {
+        configKeys = args.slice(3).join(' ')
+      }
+    }
+    if (action === 'set-maxturns') {
+      configAction = action
+      if (args.length > 2) {
+        configProvider = args[2]
+      }
+      if (args.length > 3) {
+        configMaxTurns = args[3]
+      }
     }
   }
 
@@ -398,6 +419,9 @@ export function parseArgs(argv) {
     autoUpdateIntervalHours,
     configAction,
     configPayload,
+    configProvider,
+    configKeys,
+    configMaxTurns,
     autostart: hasAutostartToken,
     onboard: hasOnboardToken,
     help: showHelp,

--- a/public/index.html
+++ b/public/index.html
@@ -1520,6 +1520,7 @@
       <div class="tab active" id="tab-models" onclick="switchTab('models')">Live Telemetry</div>
       <div class="tab" id="tab-chat" onclick="switchTab('chat')">Chat</div>
       <div class="tab" id="tab-logs" onclick="switchTab('logs')">Request Logs</div>
+      <div class="tab" id="tab-status" onclick="switchTab('status')">Account Status</div>
       <div class="tab" id="tab-settings" onclick="switchTab('settings')">Settings</div>
       <div class="tab" id="tab-setup" onclick="switchTab('setup')">Setup Instructions</div>
     </div>
@@ -1712,6 +1713,20 @@
       </div>
     </div>
 
+    <div id="status-view" style="display: none;">
+      <div class="table-container">
+        <div class="table-header">
+          <div class="table-title">Account Status</div>
+          <div style="display:flex; align-items:center; gap:10px;">
+            <button onclick="loadAccountStatus()" class="btn" style="background:white; color:var(--text); border:1px solid var(--border);">Refresh</button>
+          </div>
+        </div>
+        <div id="account-status-body">
+          <div style="padding:32px; text-align:center; color:var(--text-muted);">Loading account status...</div>
+        </div>
+      </div>
+    </div>
+
     <div id="chat-view" style="display: none;">
       <div class="chat-layout">
         <div class="chat-toolbar">
@@ -1893,6 +1908,7 @@
       document.getElementById('models-view').style.display = tab === 'models' ? 'block' : 'none';
       document.getElementById('chat-view').style.display = tab === 'chat' ? 'block' : 'none';
       document.getElementById('logs-view').style.display = tab === 'logs' ? 'block' : 'none';
+      document.getElementById('status-view').style.display = tab === 'status' ? 'block' : 'none';
       document.getElementById('settings-view').style.display = tab === 'settings' ? 'block' : 'none';
       document.getElementById('setup-view').style.display = tab === 'setup' ? 'block' : 'none';
 
@@ -1903,6 +1919,8 @@
       } else if (tab === 'chat') {
         renderChatTranscript();
         scrollChatToBottom();
+      } else if (tab === 'status') {
+        loadAccountStatus();
       }
     }
 
@@ -3405,6 +3423,33 @@
               <input type="number" id="ping-interval-${p.key}" min="1" step="1" value="${p.pingIntervalMinutes || ''}" placeholder="30" style="width:70px; padding:6px 10px; border:1px solid var(--border); border-radius:6px; font-size:0.8rem;" onchange="updateProviderPingInterval('${p.key}')">
               <span style="font-size:0.75rem; color:var(--text-muted);">(default: 30)</span>
             </div>
+            ${p.hasMultipleKeys ? `
+            <div style="margin-top:14px; padding:12px 14px; background:#f8fafc; border:1px solid var(--border); border-radius:10px;">
+              <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:10px;">
+                <span style="font-size:0.8rem; font-weight:700; color:var(--text);">Accounts (${p.apiKeyPool.length})</span>
+                <span style="font-size:0.7rem; color:var(--text-muted);">Round-robin active</span>
+              </div>
+              <div style="display:flex; flex-direction:column; gap:6px; margin-bottom:10px;">
+                ${p.apiKeyPool.map((acct, i) => `
+                  <div style="display:flex; align-items:center; gap:8px; padding:6px 8px; background:white; border:1px solid #e5e7eb; border-radius:6px; font-size:0.78rem;">
+                    <span style="font-weight:700; color:var(--text-muted); min-width:20px;">[${i}]</span>
+                    <span style="font-family:monospace; color:var(--text); flex:1;">${escapeHtml(acct.masked)}</span>
+                    <span id="acct-status-${p.key}-${i}" style="font-size:0.7rem;"></span>
+                    <button onclick="removeAccountKey('${p.key}', ${i})" style="border:1px solid #fecaca; background:#fff1f2; color:#b91c1c; cursor:pointer; padding:2px 8px; border-radius:4px; font-size:0.7rem; font-weight:600;">Remove</button>
+                  </div>
+                `).join('')}
+              </div>
+              <div style="display:flex; gap:8px; align-items:center; margin-bottom:10px;">
+                <input type="password" id="new-key-${p.key}" placeholder="Add new account key..." style="flex:1; padding:6px 10px; border:1px solid var(--border); border-radius:6px; font-size:0.78rem;">
+                <button onclick="addAccountKey('${p.key}')" style="border:1px solid #bbf7d0; background:#ecfdf5; color:#065f46; cursor:pointer; padding:6px 12px; border-radius:6px; font-size:0.78rem; font-weight:600;">Add Account</button>
+              </div>
+              <div style="display:flex; gap:8px; align-items:center;">
+                <span style="font-size:0.75rem; color:var(--text-muted); white-space:nowrap;">Max turns per account:</span>
+                <input type="number" id="maxturns-${p.key}" min="0" step="1" value="${p.maxTurns || 0}" style="width:70px; padding:5px 8px; border:1px solid var(--border); border-radius:6px; font-size:0.78rem;" onchange="updateProviderMaxTurns('${p.key}')">
+                <span style="font-size:0.72rem; color:var(--text-muted);">0 = unlimited</span>
+              </div>
+            </div>
+            ` : ''}
             ${optionalBearerAuthHtml}
             ${openAiCompatibleFieldsHtml}
             ${qwenAuthActionsHtml}
@@ -3487,6 +3532,149 @@
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ providerKey: key, pingIntervalMinutes })
       });
+    }
+
+    async function addAccountKey(providerKey) {
+      const input = document.getElementById(`new-key-${providerKey}`);
+      if (!input) return;
+      const val = input.value.trim();
+      if (!val) return;
+      try {
+        const res = await fetch('/api/config');
+        const providers = await res.json();
+        const p = providers.find(pr => pr.key === providerKey);
+        if (!p) return;
+        let newPool;
+        if (Array.isArray(p.apiKeyPool) && p.apiKeyPool.length > 0) {
+          const existingKeys = p.apiKeyPool.map(a => a.key);
+          newPool = [...existingKeys, val];
+        } else {
+          newPool = [val];
+        }
+        await fetch('/api/config', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ providerKey, apiKeys: newPool })
+        });
+        input.value = '';
+        await loadSettings();
+        await loadAccountStatus();
+      } catch (err) { console.error(err); }
+    }
+
+    async function removeAccountKey(providerKey, index) {
+      try {
+        const res = await fetch('/api/config');
+        const providers = await res.json();
+        const p = providers.find(pr => pr.key === providerKey);
+        if (!p || !Array.isArray(p.apiKeyPool)) return;
+        const newPool = p.apiKeyPool.map(a => a.key).filter((_, i) => i !== index);
+        if (newPool.length === 0) {
+          await fetch('/api/config', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ providerKey, apiKeys: [] })
+          });
+        } else {
+          await fetch('/api/config', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ providerKey, apiKeys: newPool })
+          });
+        }
+        await loadSettings();
+        await loadAccountStatus();
+      } catch (err) { console.error(err); }
+    }
+
+    async function updateProviderMaxTurns(providerKey) {
+      const input = document.getElementById(`maxturns-${providerKey}`);
+      if (!input) return;
+      const val = input.value.trim();
+      const parsed = Math.floor(Number(val));
+      const maxTurns = Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
+      await fetch('/api/config', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ providerKey, maxTurns })
+      });
+    }
+
+    async function loadAccountStatus() {
+      const body = document.getElementById('account-status-body');
+      if (!body) return;
+      body.innerHTML = '<div style="padding:32px; text-align:center; color:var(--text-muted);">Loading account status...</div>';
+      try {
+        const [statusRes, configRes] = await Promise.all([
+          fetch('/api/account-status'),
+          fetch('/api/config')
+        ]);
+        const status = await statusRes.json();
+        const config = await configRes.json();
+        const providers = status.providers || {};
+        const providerNames = {};
+        for (const p of config) { providerNames[p.key] = p.name; }
+
+        const providerKeys = Object.keys(providers);
+        if (providerKeys.length === 0) {
+          body.innerHTML = '<div style="padding:32px; text-align:center; color:var(--text-muted);">No multi-account providers configured.<br><br>Add multiple API keys to a provider to enable round-robin.</div>';
+          return;
+        }
+
+        let html = `<table style="width:100%;">
+          <thead>
+            <tr>
+              <th style="text-align:left; padding:12px 24px; font-size:0.75rem; color:var(--text-muted); font-weight:600; background:#faf9f8;">Provider</th>
+              <th style="text-align:left; padding:12px 24px; font-size:0.75rem; color:var(--text-muted); font-weight:600; background:#faf9f8;">Account</th>
+              <th style="text-align:left; padding:12px 24px; font-size:0.75rem; color:var(--text-muted); font-weight:600; background:#faf9f8;">Status</th>
+              <th style="text-align:right; padding:12px 24px; font-size:0.75rem; color:var(--text-muted); font-weight:600; background:#faf9f8;">Requests</th>
+              <th style="text-align:right; padding:12px 24px; font-size:0.75rem; color:var(--text-muted); font-weight:600; background:#faf9f8;">Max Turns</th>
+              <th style="text-align:center; padding:12px 24px; font-size:0.75rem; color:var(--text-muted); font-weight:600; background:#faf9f8;">Next</th>
+            </tr>
+          </thead>
+          <tbody>`;
+
+        for (const [key, info] of Object.entries(providers)) {
+          const name = providerNames[key] || key;
+          const maxTurns = info.maxTurns || 0;
+          for (const acct of info.accounts) {
+            const isRateLimited = acct.rateLimited;
+            const hitMaxTurns = maxTurns > 0 && acct.requests >= maxTurns;
+            let statusIcon = '🟢';
+            let statusColor = '#065f46';
+            let statusBg = '#ecfdf5';
+            let statusText = 'Active';
+            if (isRateLimited) {
+              statusIcon = '🔴';
+              statusColor = '#7f1d1d';
+              statusBg = '#fef2f2';
+              statusText = 'Rate Limited';
+            } else if (hitMaxTurns) {
+              statusIcon = '🟡';
+              statusColor = '#92400e';
+              statusBg = '#fffbeb';
+              statusText = 'Cooling';
+            }
+            const isNext = acct.index === info.currentIdx;
+            html += `<tr style="border-bottom:1px solid var(--border);">
+              <td style="padding:14px 24px; font-size:0.875rem; font-weight:600;">${escapeHtml(name)}</td>
+              <td style="padding:14px 24px; font-size:0.875rem;">
+                <span style="font-family:monospace; background:#f3f2f1; padding:2px 6px; border-radius:4px; font-size:0.78rem;">[${acct.index}] ${escapeHtml(acct.masked)}</span>
+              </td>
+              <td style="padding:14px 24px;">
+                <span style="background:${statusBg}; color:${statusColor}; border-radius:999px; padding:2px 10px; font-size:0.72rem; font-weight:700;">${statusIcon} ${statusText}</span>
+              </td>
+              <td style="padding:14px 24px; text-align:right; font-size:0.875rem; font-weight:600; font-variant-numeric:tabular-nums;">${acct.requests}</td>
+              <td style="padding:14px 24px; text-align:right; font-size:0.875rem; color:var(--text-muted);">${maxTurns > 0 ? maxTurns : 'unlimited'}</td>
+              <td style="padding:14px 24px; text-align:center; font-size:1.1rem;">${isNext ? '→' : ''}</td>
+            </tr>`;
+          }
+        }
+        html += '</tbody></table>';
+        body.innerHTML = html;
+      } catch (err) {
+        body.innerHTML = '<div style="padding:32px; text-align:center; color:var(--error);">Failed to load account status.</div>';
+      }
     }
 
     async function updateProviderBearerAuth(key) {

--- a/public/index.html
+++ b/public/index.html
@@ -3423,11 +3423,11 @@
               <input type="number" id="ping-interval-${p.key}" min="1" step="1" value="${p.pingIntervalMinutes || ''}" placeholder="30" style="width:70px; padding:6px 10px; border:1px solid var(--border); border-radius:6px; font-size:0.8rem;" onchange="updateProviderPingInterval('${p.key}')">
               <span style="font-size:0.75rem; color:var(--text-muted);">(default: 30)</span>
             </div>
-            ${p.hasMultipleKeys ? `
+            ${(Array.isArray(p.apiKeyPool) && p.apiKeyPool.length > 0) ? `
             <div style="margin-top:14px; padding:12px 14px; background:#f8fafc; border:1px solid var(--border); border-radius:10px;">
               <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:10px;">
                 <span style="font-size:0.8rem; font-weight:700; color:var(--text);">Accounts (${p.apiKeyPool.length})</span>
-                <span style="font-size:0.7rem; color:var(--text-muted);">Round-robin active</span>
+                <span style="font-size:0.7rem; color:var(--text-muted);">${p.apiKeyPool.length > 1 ? 'Round-robin active' : 'Add one more key to enable round-robin'}</span>
               </div>
               <div style="display:flex; flex-direction:column; gap:6px; margin-bottom:10px;">
                 ${p.apiKeyPool.map((acct, i) => `

--- a/test/test.js
+++ b/test/test.js
@@ -18,6 +18,7 @@ import {
   isRetryableProxyStatus,
   parseArgs,
   parseOpenRouterKeyRateLimit,
+  selectNextApiKeyFromPool,
   VERDICT_ORDER,
 } from '../lib/utils.js'
 import { buildOpenClawProviderConfig } from '../lib/onboard.js'
@@ -1477,6 +1478,46 @@ describe('multi-account round-robin', () => {
     it('returns empty when pool state is not initialized', () => {
       const result = getAccountStatus({ apiKeys: { kilocode: ['k1', 'k2'] } })
       assert.deepEqual(result, { providers: {} })
+    })
+  })
+
+  describe('selectNextApiKeyFromPool', () => {
+    it('returns null when every key is still inside cooldown', () => {
+      const now = 1_000_000
+      const pool = ['key1', 'key2']
+      const entry = {
+        currentIdx: 0,
+        accounts: new Map([
+          [0, { requests: 1, rateLimitedAt: now - 10_000 }],
+          [1, { requests: 1, rateLimitedAt: now - 20_000 }],
+        ]),
+      }
+
+      const selected = selectNextApiKeyFromPool(pool, entry, 0, now, 60_000)
+
+      assert.equal(selected, null)
+      assert.equal(entry.currentIdx, 0)
+      assert.equal(entry.accounts.get(0).requests, 1)
+      assert.equal(entry.accounts.get(1).requests, 1)
+    })
+
+    it('resets counters when only maxTurns exhaustion blocks the pool', () => {
+      const now = 1_000_000
+      const pool = ['key1', 'key2']
+      const entry = {
+        currentIdx: 0,
+        accounts: new Map([
+          [0, { requests: 2, rateLimitedAt: 0 }],
+          [1, { requests: 2, rateLimitedAt: 0 }],
+        ]),
+      }
+
+      const selected = selectNextApiKeyFromPool(pool, entry, 2, now, 60_000)
+
+      assert.equal(selected, 'key1')
+      assert.equal(entry.currentIdx, 1)
+      assert.equal(entry.accounts.get(0).requests, 1)
+      assert.equal(entry.accounts.get(1).requests, 0)
     })
   })
 })

--- a/test/test.js
+++ b/test/test.js
@@ -25,7 +25,7 @@ import { resolveAutostartExecPath, resolveAutostartNodePath } from '../lib/autos
 import { exportConfigToken, getApiKey, getApiKeyPool, getMaxTurns, getPinningMode, getProviderBaseUrl, getProviderModelId, getProviderPingIntervalMs, hasMultipleKeys, importConfigToken, normalizeConfigShape } from '../lib/config.js'
 import { buildNpmInstallInvocation, buildWindowsPostUpdateRestartCommand, getForcedUpdateVersion, getLocalUpdateTarballPath, getLocalUpdateVersion, isRunningFromSource, shouldStopAutostartBeforeUpdate } from '../lib/update.js'
 import { isQwenOauthAccessTokenValid, pollQwenOauthDeviceToken, resolveQwenCodeOauthAccessToken, startQwenOauthDeviceLogin } from '../lib/qwencodeAuth.js'
-import { buildOpencodeHeaders, buildOpencodeProjectId, buildProviderRequestHeaders, extractOllamaModelRecords, getPinnedModelCandidate, getPinnedModelMatches, isProviderAuthOptional, isProviderBearerAuthEnabled, providerWantsBearerAuth, shouldRetryOptionalProviderWithBearer, toOllamaModelMeta, toOpenCodeModelMeta, toOpenRouterModelMeta, toKiloCodeModelMeta } from '../lib/server.js'
+import { buildOpencodeHeaders, buildOpencodeProjectId, buildProviderRequestHeaders, extractOllamaModelRecords, getAccountStatus, getPinnedModelCandidate, getPinnedModelMatches, isProviderAuthOptional, isProviderBearerAuthEnabled, providerWantsBearerAuth, shouldRetryOptionalProviderWithBearer, toOllamaModelMeta, toOpenCodeModelMeta, toOpenRouterModelMeta, toKiloCodeModelMeta } from '../lib/server.js'
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const ROOT = join(__dirname, '..')
 
@@ -980,6 +980,50 @@ describe('parseArgs', () => {
     assert.equal(imported.configAction, 'import')
     assert.equal(imported.configPayload, 'mrconf:v1:abc123')
   })
+
+  it('parses config set-keys command', () => {
+    const result = parseArgs(argv('config', 'set-keys', 'kilocode', 'key1,key2,key3'))
+    assert.equal(result.command, 'config')
+    assert.equal(result.configAction, 'set-keys')
+    assert.equal(result.configProvider, 'kilocode')
+    assert.equal(result.configKeys, 'key1,key2,key3')
+  })
+
+  it('parses config add-key command', () => {
+    const result = parseArgs(argv('config', 'add-key', 'nvidia', 'nvapi-extra'))
+    assert.equal(result.command, 'config')
+    assert.equal(result.configAction, 'add-key')
+    assert.equal(result.configProvider, 'nvidia')
+    assert.equal(result.configKeys, 'nvapi-extra')
+  })
+
+  it('parses config remove-key command', () => {
+    const result = parseArgs(argv('config', 'remove-key', 'groq', '1'))
+    assert.equal(result.command, 'config')
+    assert.equal(result.configAction, 'remove-key')
+    assert.equal(result.configProvider, 'groq')
+    assert.equal(result.configKeys, '1')
+  })
+
+  it('parses config set-maxturns command', () => {
+    const result = parseArgs(argv('config', 'set-maxturns', 'kilocode', '20'))
+    assert.equal(result.command, 'config')
+    assert.equal(result.configAction, 'set-maxturns')
+    assert.equal(result.configProvider, 'kilocode')
+    assert.equal(result.configMaxTurns, '20')
+  })
+
+  it('parses config set-maxturns with 0 to disable', () => {
+    const result = parseArgs(argv('config', 'set-maxturns', 'kilocode', '0'))
+    assert.equal(result.command, 'config')
+    assert.equal(result.configAction, 'set-maxturns')
+    assert.equal(result.configMaxTurns, '0')
+  })
+
+  it('parses status command', () => {
+    const result = parseArgs(argv('status'))
+    assert.equal(result.command, 'status')
+  })
 })
 
 describe('parseOpenRouterKeyRateLimit', () => {
@@ -1426,6 +1470,13 @@ describe('multi-account round-robin', () => {
       const imported = importConfigToken(token)
       assert.deepEqual(imported.apiKeys.kilocode, ['key1', 'key2'])
       assert.equal(imported.apiKeys.nvidia, 'nv-key')
+    })
+  })
+
+  describe('getAccountStatus', () => {
+    it('returns empty when pool state is not initialized', () => {
+      const result = getAccountStatus({ apiKeys: { kilocode: ['k1', 'k2'] } })
+      assert.deepEqual(result, { providers: {} })
     })
   })
 })

--- a/test/test.js
+++ b/test/test.js
@@ -22,7 +22,7 @@ import {
 } from '../lib/utils.js'
 import { buildOpenClawProviderConfig } from '../lib/onboard.js'
 import { resolveAutostartExecPath, resolveAutostartNodePath } from '../lib/autostart.js'
-import { exportConfigToken, getApiKey, getPinningMode, getProviderBaseUrl, getProviderModelId, getProviderPingIntervalMs, importConfigToken } from '../lib/config.js'
+import { exportConfigToken, getApiKey, getApiKeyPool, getMaxTurns, getPinningMode, getProviderBaseUrl, getProviderModelId, getProviderPingIntervalMs, hasMultipleKeys, importConfigToken, normalizeConfigShape } from '../lib/config.js'
 import { buildNpmInstallInvocation, buildWindowsPostUpdateRestartCommand, getForcedUpdateVersion, getLocalUpdateTarballPath, getLocalUpdateVersion, isRunningFromSource, shouldStopAutostartBeforeUpdate } from '../lib/update.js'
 import { isQwenOauthAccessTokenValid, pollQwenOauthDeviceToken, resolveQwenCodeOauthAccessToken, startQwenOauthDeviceLogin } from '../lib/qwencodeAuth.js'
 import { buildOpencodeHeaders, buildOpencodeProjectId, buildProviderRequestHeaders, extractOllamaModelRecords, getPinnedModelCandidate, getPinnedModelMatches, isProviderAuthOptional, isProviderBearerAuthEnabled, providerWantsBearerAuth, shouldRetryOptionalProviderWithBearer, toOllamaModelMeta, toOpenCodeModelMeta, toOpenRouterModelMeta, toKiloCodeModelMeta } from '../lib/server.js'
@@ -1282,5 +1282,150 @@ describe('package and entrypoint sanity', () => {
     assert.ok(binContent.startsWith('#!/usr/bin/env node'))
     assert.ok(binContent.includes("from '../lib/utils.js'"))
     assert.ok(binContent.includes("from '../lib/onboard.js'"))
+  })
+})
+
+describe('multi-account round-robin', () => {
+  describe('getApiKeyPool', () => {
+    it('returns single-element array for string key', () => {
+      const config = { apiKeys: { nvidia: 'nvapi-key1' } }
+      assert.deepEqual(getApiKeyPool(config, 'nvidia'), ['nvapi-key1'])
+    })
+
+    it('returns array for array keys', () => {
+      const config = { apiKeys: { kilocode: ['key1', 'key2', 'key3'] } }
+      assert.deepEqual(getApiKeyPool(config, 'kilocode'), ['key1', 'key2', 'key3'])
+    })
+
+    it('returns empty array for missing provider', () => {
+      const config = { apiKeys: {} }
+      assert.deepEqual(getApiKeyPool(config, 'nvidia'), [])
+    })
+
+    it('filters empty strings from array', () => {
+      const config = { apiKeys: { groq: ['key1', '', '  ', 'key2'] } }
+      assert.deepEqual(getApiKeyPool(config, 'groq'), ['key1', 'key2'])
+    })
+
+    it('trims whitespace from keys', () => {
+      const config = { apiKeys: { groq: ['  key1  ', '  key2  '] } }
+      assert.deepEqual(getApiKeyPool(config, 'groq'), ['key1', 'key2'])
+    })
+
+    it('env var overrides return single-element array', () => {
+      withEnv({ NVIDIA_API_KEY: 'env-key' }, () => {
+        const config = { apiKeys: { nvidia: ['file-key1', 'file-key2'] } }
+        assert.deepEqual(getApiKeyPool(config, 'nvidia'), ['env-key'])
+      })
+    })
+
+    it('qwencode env var works with DASHSCOPE_API_KEY fallback', () => {
+      withEnv({ DASHSCOPE_API_KEY: 'dashscope-key' }, () => {
+        assert.deepEqual(getApiKeyPool({ apiKeys: {} }, 'qwencode'), ['dashscope-key'])
+      })
+    })
+  })
+
+  describe('getApiKey backward compatibility', () => {
+    it('returns first element for array keys', () => {
+      const config = { apiKeys: { kilocode: ['key1', 'key2', 'key3'] } }
+      assert.equal(getApiKey(config, 'kilocode'), 'key1')
+    })
+
+    it('returns string for string keys', () => {
+      const config = { apiKeys: { nvidia: 'nvapi-key1' } }
+      assert.equal(getApiKey(config, 'nvidia'), 'nvapi-key1')
+    })
+
+    it('returns null for empty array', () => {
+      const config = { apiKeys: { groq: [] } }
+      assert.equal(getApiKey(config, 'groq'), null)
+    })
+  })
+
+  describe('hasMultipleKeys', () => {
+    it('returns true for multiple array keys', () => {
+      const config = { apiKeys: { kilocode: ['key1', 'key2'] } }
+      assert.equal(hasMultipleKeys(config, 'kilocode'), true)
+    })
+
+    it('returns false for single string key', () => {
+      const config = { apiKeys: { nvidia: 'nvapi-key1' } }
+      assert.equal(hasMultipleKeys(config, 'nvidia'), false)
+    })
+
+    it('returns false for single-element array', () => {
+      const config = { apiKeys: { groq: ['key1'] } }
+      assert.equal(hasMultipleKeys(config, 'groq'), false)
+    })
+
+    it('returns false for missing provider', () => {
+      assert.equal(hasMultipleKeys({ apiKeys: {} }, 'nvidia'), false)
+    })
+  })
+
+  describe('getMaxTurns', () => {
+    it('returns configured value', () => {
+      const config = { providers: { kilocode: { maxTurns: 20 } } }
+      assert.equal(getMaxTurns(config, 'kilocode'), 20)
+    })
+
+    it('returns 0 when not configured', () => {
+      assert.equal(getMaxTurns({ providers: {} }, 'kilocode'), 0)
+      assert.equal(getMaxTurns({ providers: { kilocode: {} } }, 'kilocode'), 0)
+    })
+
+    it('returns 0 for invalid values', () => {
+      const config = { providers: { kilocode: { maxTurns: -1 } } }
+      assert.equal(getMaxTurns(config, 'kilocode'), 0)
+      const config2 = { providers: { kilocode: { maxTurns: 'abc' } } }
+      assert.equal(getMaxTurns(config2, 'kilocode'), 0)
+    })
+
+    it('floors fractional values', () => {
+      const config = { providers: { kilocode: { maxTurns: 10.7 } } }
+      assert.equal(getMaxTurns(config, 'kilocode'), 10)
+    })
+  })
+
+  describe('normalizeConfigShape with arrays', () => {
+    it('normalizes array apiKeys by trimming and filtering', () => {
+      const config = {
+        apiKeys: { kilocode: ['  key1  ', '', 'key2'] },
+        providers: {},
+      }
+      const normalized = normalizeConfigShape(config)
+      assert.deepEqual(normalized.apiKeys.kilocode, ['key1', 'key2'])
+    })
+
+    it('preserves string apiKeys unchanged', () => {
+      const config = {
+        apiKeys: { nvidia: '  nv-key  ' },
+        providers: {},
+      }
+      const normalized = normalizeConfigShape(config)
+      assert.equal(normalized.apiKeys.nvidia, 'nv-key')
+    })
+
+    it('handles mixed string and array apiKeys', () => {
+      const config = {
+        apiKeys: { nvidia: 'nv-key', kilocode: ['key1', 'key2'] },
+        providers: {},
+      }
+      const normalized = normalizeConfigShape(config)
+      assert.equal(normalized.apiKeys.nvidia, 'nv-key')
+      assert.deepEqual(normalized.apiKeys.kilocode, ['key1', 'key2'])
+    })
+
+    it('round-trips through export/import with array keys', () => {
+      const config = {
+        apiKeys: { kilocode: ['key1', 'key2'], nvidia: 'nv-key' },
+        providers: { kilocode: { enabled: true } },
+      }
+      const token = exportConfigToken(config)
+      const imported = importConfigToken(token)
+      assert.deepEqual(imported.apiKeys.kilocode, ['key1', 'key2'])
+      assert.equal(imported.apiKeys.nvidia, 'nv-key')
+    })
   })
 })


### PR DESCRIPTION
## Summary

This PR adds multi-account API key rotation support in a clean form on top of current `master`.

It keeps only the multi-account work from the earlier branch and drops unrelated commits so the diff is easier to review and merge.

## What changed

- allow `apiKeys` entries to be either a single string or an array of keys
- add round-robin account selection with `maxTurns` and `429` cooldown handling
- expose multi-account management through the CLI and web UI
- add account status reporting for active key pools
- extend onboarding and config APIs for multi-account providers
- add regression coverage for config parsing, rotation helpers, CLI parsing, and account status

## Why

The previous branch mixed the multi-account feature with unrelated history and merge noise. This replacement branch preserves the useful feature work while keeping the review surface focused on the behavior we actually want to merge.

## Validation

- `pnpm test`
- Result: 133 tests passing
