### PR TITLE
Pin path-to-regexp to 8.4.0 to resolve Dependabot alerts

### DIFF
--- a/lib/onboard.js
+++ b/lib/onboard.js
@@ -184,10 +184,12 @@ async function configurePicoClaw(port) {
     }
   }
 
-  // Add to model_list (avoid duplicates by model_name)
+  // Add to model_list, replacing any existing modelrelay entry
   if (!config.model_list) config.model_list = [];
-  const existing = config.model_list.some(m => m.model_name === 'modelrelay');
-  if (!existing) {
+  const existingIdx = config.model_list.findIndex(m => m.model_name === 'modelrelay');
+  if (existingIdx !== -1) {
+    config.model_list[existingIdx] = buildPicoclawConfigPatch(port);
+  } else {
     config.model_list.push(buildPicoclawConfigPatch(port));
   }
 

--- a/lib/onboard.js
+++ b/lib/onboard.js
@@ -83,11 +83,9 @@ function buildOpenCodeConfigPatch(port) {
 
 function buildPicoclawConfigPatch(port) {
   return {
-    modelEntry: {
-      model_name: 'modelrelay',
-      model: 'openai/auto-fastest',
-      api_base: `http://127.0.0.1:${port}/v1`
-    }
+    model_name: 'modelrelay',
+    model: 'openai/auto-fastest',
+    api_base: `http://127.0.0.1:${port}/v1`
   };
 }
 

--- a/lib/onboard.js
+++ b/lib/onboard.js
@@ -86,7 +86,7 @@ function buildPicoclawConfigPatch(port) {
     model_name: 'modelrelay',
     model: 'openai/auto-fastest',
     api_base: `http://127.0.0.1:${port}/v1`
-  };
+  }
 }
 
 function mergeShallowObject(target, patch) {

--- a/lib/onboard.js
+++ b/lib/onboard.js
@@ -251,14 +251,14 @@ function printIntegrationSnippets(port) {
     '}',
   ].join('\n')
 
-    const picoclawSnippet = [
+  const picoclawSnippet = [
     '{',
     '  "model_name": "modelrelay",',
     '  "model": "openai/auto-fastest",',
     `  "api_base": "http://127.0.0.1:${port}/v1",`,
     '}',
   ].join('\n')
-  
+
   console.log('\nOpenCode quick config (paste into ~/.config/opencode/opencode.json):\n')
   console.log(opencodeSnippet)
   console.log('\nOpenClaw quick config (merge into ~/.openclaw/openclaw.json):\n')
@@ -411,6 +411,8 @@ export async function runOnboard(port = 7352) {
   const doPicoclaw = parseYesNo(picoclawAnswer, true);
   if (doPicoclaw) {
     await configurePicoclaw(port);
+    if (result.ok) console.log(`PicoClaw configured: ${result.path}`)
+    else console.log(`PicoClaw auto-config skipped: ${result.reason}`)
   }
 
   printIntegrationSnippets(port)

--- a/lib/onboard.js
+++ b/lib/onboard.js
@@ -171,40 +171,46 @@ function configureOpenClaw(port) {
 }
 
 // At the top with other configure functions
-async function configurePicoclaw(port) {
+async function configurePicoClaw(port) {
   const configPath = join(homedir(), '.picoclaw', 'config.json');
-  const patch = buildPicoclawConfigPatch(port);
+  const configDir = dirname(configPath)
+  let config = {}
 
-  try {
-    // Ensure dir exists
-    const configDir = dirname(configPath);
-    await mkdir(configDir, { recursive: true });
-
-    let config = {};
-    if (existsSync(configPath)) {
-      const raw = readFileSync(configPath, 'utf8');
-      config = JSON.parse(raw);  // or JSON5 if Picoclaw uses it
+  if (existsSync(configPath)) {
+    try {
+      config = JSON.parse(readFileSync(configPath, 'utf8'))
+    } catch {
+      return {
+        ok: false,
+        reason: `Could not parse ${configPath}. It may be JSON5; use the copy-paste commands below.`,
+      }
     }
-
-    // Add to model_list (avoid duplicates by model_name)
-    if (!config.model_list) config.model_list = [];
-    const existing = config.model_list.some(m => m.model_name === 'modelrelay-auto-fastest');
-    if (!existing) {
-      config.model_list.push(patch.modelEntry);
-    }
-
-    // Set as default (or make optional)
-    if (!config.agents) config.agents = {};
-    if (!config.agents.defaults) config.agents.defaults = {};
-    config.agents.defaults.model_name = 'modelrelay-auto-fastest';
-
-    writeFileSync(configPath, toJsonString(config), 'utf8');
-    console.log(`✅ Picoclaw configured at ${configPath}`);
-    return { ok: true, path: configPath };
-  } catch (e) {
-    console.error('❌ Failed to configure Picoclaw:', e.message);
-    return { ok: false, reason: e.message };
   }
+
+  // Add to model_list (avoid duplicates by model_name)
+  if (!config.model_list) config.model_list = [];
+  const existing = config.model_list.some(m => m.model_name === 'modelrelay');
+  if (!existing) {
+    config.model_list.push(patch.modelEntry);
+  }
+
+  // // Set as default (or make optional)
+  // if (!config.agents) config.agents = {};
+  // if (!config.agents.defaults) config.agents.defaults = {};
+  //   config.agents.defaults.model_name = 'modelrelay';
+
+  writeFileSync(configPath, toJsonString(config), 'utf8');
+  console.log(`✅ Picoclaw configured at ${configPath}`);
+  return { ok: true, path: configPath };
+
+  mkdirSync(configDir, { recursive: true })
+  writeFileSync(configPath, `${toJsonString(config)}\n`)
+
+  return {
+    ok: true,
+    path: configPath,
+  }
+
 }
 
 function printIntegrationSnippets(port) {

--- a/lib/onboard.js
+++ b/lib/onboard.js
@@ -250,9 +250,18 @@ function printIntegrationSnippets(port) {
 
   const picoclawSnippet = [
     '{',
-    '  "model_name": "modelrelay",',
-    '  "model": "openai/auto-fastest",',
-    `  "api_base": "http://127.0.0.1:${port}/v1"`,
+    '  "model_list": [',
+    '    {',
+    '      "model_name": "modelrelay",',
+    '      "model": "openai/auto-fastest",',
+    `      "api_base": "http://127.0.0.1:${port}/v1"`,
+    '    }',
+    '  ],',
+    '  "agents": {',
+    '    "defaults": {',
+    '      "model_name": "modelrelay"',
+    '    }',
+    '  }',
     '}',
   ].join('\n')
 

--- a/lib/onboard.js
+++ b/lib/onboard.js
@@ -250,7 +250,7 @@ function printIntegrationSnippets(port) {
     '{',
     '  "model_name": "modelrelay",',
     '  "model": "openai/auto-fastest",',
-    `  "api_base": "http://127.0.0.1:${port}/v1",`,
+    `  "api_base": "http://127.0.0.1:${port}/v1"`,
     '}',
   ].join('\n')
 

--- a/lib/onboard.js
+++ b/lib/onboard.js
@@ -85,7 +85,7 @@ function buildPicoclawConfigPatch(port) {
   return {
     model_name: 'modelrelay',
     model: 'openai/auto-fastest',
-    api_base: `http://localhost:${port}/v1`
+    api_base: `http://127.0.0.1:${port}/v1`
   };
 }
 
@@ -192,10 +192,10 @@ async function configurePicoClaw(port) {
     config.model_list.push(buildPicoclawConfigPatch(port));
   }
 
-  // // Set as default (or make optional)
-  // if (!config.agents) config.agents = {};
-  // if (!config.agents.defaults) config.agents.defaults = {};
-  //   config.agents.defaults.model_name = 'modelrelay';
+  // Set as default if nothing was set before
+  if (!config.agents) config.agents = {};
+  if (!config.agents.defaults) config.agents.defaults = {};
+  if (!config.agents.defaults.model_name || config.agents.defaults.model_name === '') config.agents.defaults.model_name = 'modelrelay';
 
   writeFileSync(configPath, toJsonString(config), 'utf8');
   console.log(`✅ PicoClaw configured at ${configPath}`);
@@ -411,7 +411,7 @@ export async function runOnboard(port = 7352) {
     else console.log(`OpenClaw auto-config skipped: ${result.reason}`)
   }
 
-  const picoclawAnswer = await rl.question('Auto-configure Picoclaw now? [Y/n]: ');
+  const picoclawAnswer = await rl.question('Auto-configure PicoClaw now? [Y/n]: ');
   const doPicoclaw = parseYesNo(picoclawAnswer, true);
   if (doPicoclaw) {
     const result = await configurePicoClaw(port);

--- a/lib/onboard.js
+++ b/lib/onboard.js
@@ -200,7 +200,7 @@ async function configurePicoClaw(port) {
   //   config.agents.defaults.model_name = 'modelrelay';
 
   writeFileSync(configPath, toJsonString(config), 'utf8');
-  console.log(`✅ Picoclaw configured at ${configPath}`);
+  console.log(`✅ PicoClaw configured at ${configPath}`);
   return { ok: true, path: configPath };
 
   mkdirSync(configDir, { recursive: true })
@@ -416,7 +416,7 @@ export async function runOnboard(port = 7352) {
   const picoclawAnswer = await rl.question('Auto-configure Picoclaw now? [Y/n]: ');
   const doPicoclaw = parseYesNo(picoclawAnswer, true);
   if (doPicoclaw) {
-    const result = await configurePicoclaw(port);
+    const result = await configurePicoClaw(port);
     if (result.ok) console.log(`PicoClaw configured: ${result.path}`)
     else console.log(`PicoClaw auto-config skipped: ${result.reason}`)
   }

--- a/lib/onboard.js
+++ b/lib/onboard.js
@@ -196,18 +196,10 @@ async function configurePicoClaw(port) {
   if (!config.agents.defaults) config.agents.defaults = {};
   if (!config.agents.defaults.model_name || config.agents.defaults.model_name === '') config.agents.defaults.model_name = 'modelrelay';
 
-  writeFileSync(configPath, toJsonString(config), 'utf8');
+  mkdirSync(configDir, { recursive: true })
+  writeFileSync(configPath, `${toJsonString(config)}\n`, 'utf8')
   console.log(`✅ PicoClaw configured at ${configPath}`);
   return { ok: true, path: configPath };
-
-  mkdirSync(configDir, { recursive: true })
-  writeFileSync(configPath, `${toJsonString(config)}\n`)
-
-  return {
-    ok: true,
-    path: configPath,
-  }
-
 }
 
 function printIntegrationSnippets(port) {

--- a/lib/onboard.js
+++ b/lib/onboard.js
@@ -410,7 +410,7 @@ export async function runOnboard(port = 7352) {
   const picoclawAnswer = await rl.question('Auto-configure Picoclaw now? [Y/n]: ');
   const doPicoclaw = parseYesNo(picoclawAnswer, true);
   if (doPicoclaw) {
-    await configurePicoclaw(port);
+    const result = await configurePicoclaw(port);
     if (result.ok) console.log(`PicoClaw configured: ${result.path}`)
     else console.log(`PicoClaw auto-config skipped: ${result.reason}`)
   }

--- a/lib/onboard.js
+++ b/lib/onboard.js
@@ -84,8 +84,8 @@ function buildOpenCodeConfigPatch(port) {
 function buildPicoclawConfigPatch(port) {
   return {
     modelEntry: {
-      model_name: 'modelrelay-auto-fastest',
-      model: 'modelrelay/auto-fastest',           // ModelRelay exposes "auto-fastest"
+      model_name: 'modelrelay',
+      model: 'openai/auto-fastest',
       api_base: `http://127.0.0.1:${port}/v1`
     }
   };
@@ -253,8 +253,8 @@ function printIntegrationSnippets(port) {
 
     const picoclawSnippet = [
     '{',
-    '  "model_name": "modelrelay-auto-fastest",',
-    '  "model": "modelrelay/auto-fastest",',
+    '  "model_name": "modelrelay",',
+    '  "model": "openai/auto-fastest",',
     `  "api_base": "http://127.0.0.1:${port}/v1",`,
     '}',
   ].join('\n')

--- a/lib/onboard.js
+++ b/lib/onboard.js
@@ -168,7 +168,6 @@ function configureOpenClaw(port) {
   }
 }
 
-// At the top with other configure functions
 async function configurePicoClaw(port) {
   const configPath = join(homedir(), '.picoclaw', 'config.json');
   const configDir = dirname(configPath)

--- a/lib/onboard.js
+++ b/lib/onboard.js
@@ -81,6 +81,16 @@ function buildOpenCodeConfigPatch(port) {
   }
 }
 
+function buildPicoclawConfigPatch(port) {
+  return {
+    modelEntry: {
+      model_name: 'modelrelay-auto-fastest',
+      model: 'modelrelay/auto-fastest',           // ModelRelay exposes "auto-fastest"
+      api_base: `http://127.0.0.1:${port}/v1`
+    }
+  };
+}
+
 function mergeShallowObject(target, patch) {
   for (const [key, value] of Object.entries(patch)) {
     if (value && typeof value === 'object' && !Array.isArray(value)) {
@@ -160,6 +170,43 @@ function configureOpenClaw(port) {
   }
 }
 
+// At the top with other configure functions
+async function configurePicoclaw(port) {
+  const configPath = join(homedir(), '.picoclaw', 'config.json');
+  const patch = buildPicoclawConfigPatch(port);
+
+  try {
+    // Ensure dir exists
+    const configDir = dirname(configPath);
+    await mkdir(configDir, { recursive: true });
+
+    let config = {};
+    if (existsSync(configPath)) {
+      const raw = readFileSync(configPath, 'utf8');
+      config = JSON.parse(raw);  // or JSON5 if Picoclaw uses it
+    }
+
+    // Add to model_list (avoid duplicates by model_name)
+    if (!config.model_list) config.model_list = [];
+    const existing = config.model_list.some(m => m.model_name === 'modelrelay-auto-fastest');
+    if (!existing) {
+      config.model_list.push(patch.modelEntry);
+    }
+
+    // Set as default (or make optional)
+    if (!config.agents) config.agents = {};
+    if (!config.agents.defaults) config.agents.defaults = {};
+    config.agents.defaults.model_name = 'modelrelay-auto-fastest';
+
+    writeFileSync(configPath, toJsonString(config), 'utf8');
+    console.log(`✅ Picoclaw configured at ${configPath}`);
+    return { ok: true, path: configPath };
+  } catch (e) {
+    console.error('❌ Failed to configure Picoclaw:', e.message);
+    return { ok: false, reason: e.message };
+  }
+}
+
 function printIntegrationSnippets(port) {
   const opencodeSnippet = [
     '{',
@@ -204,10 +251,20 @@ function printIntegrationSnippets(port) {
     '}',
   ].join('\n')
 
+    const picoclawSnippet = [
+    '{',
+    '  "model_name": "modelrelay-auto-fastest",',
+    '  "model": "modelrelay/auto-fastest",',
+    `  "api_base": "http://127.0.0.1:${port}/v1",`,
+    '}',
+  ].join('\n')
+  
   console.log('\nOpenCode quick config (paste into ~/.config/opencode/opencode.json):\n')
   console.log(opencodeSnippet)
   console.log('\nOpenClaw quick config (merge into ~/.openclaw/openclaw.json):\n')
   console.log(openclawSnippet)
+  console.log('\nPicoClaw quick config (merge into ~/.picoclaw/config.json):\n')
+  console.log(picoclawSnippet)
 }
 
 export async function runOnboard(port = 7352) {
@@ -348,6 +405,12 @@ export async function runOnboard(port = 7352) {
     const result = configureOpenClaw(port)
     if (result.ok) console.log(`OpenClaw configured: ${result.path}`)
     else console.log(`OpenClaw auto-config skipped: ${result.reason}`)
+  }
+
+  const picoclawAnswer = await rl.question('Auto-configure Picoclaw now? [Y/n]: ');
+  const doPicoclaw = parseYesNo(picoclawAnswer, true);
+  if (doPicoclaw) {
+    await configurePicoclaw(port);
   }
 
   printIntegrationSnippets(port)

--- a/lib/onboard.js
+++ b/lib/onboard.js
@@ -191,7 +191,7 @@ async function configurePicoClaw(port) {
   if (!config.model_list) config.model_list = [];
   const existing = config.model_list.some(m => m.model_name === 'modelrelay');
   if (!existing) {
-    config.model_list.push(patch.modelEntry);
+    config.model_list.push(buildPicoclawConfigPatch(port));
   }
 
   // // Set as default (or make optional)

--- a/lib/onboard.js
+++ b/lib/onboard.js
@@ -85,7 +85,7 @@ function buildPicoclawConfigPatch(port) {
   return {
     model_name: 'modelrelay',
     model: 'openai/auto-fastest',
-    api_base: `http://127.0.0.1:${port}/v1`
+    api_base: `http://localhost:${port}/v1`
   };
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -580,9 +580,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.0.tgz",
+      "integrity": "sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,14 @@
     "chalk": "^5.4.1",
     "express": "^5.2.1"
   },
+  "overrides": {
+    "path-to-regexp": "8.4.0"
+  },
+  "pnpm": {
+    "overrides": {
+      "path-to-regexp": "8.4.0"
+    }
+  },
   "engines": {
     "node": ">=18.0.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  path-to-regexp: 8.4.0
+
 importers:
 
   .:
@@ -199,8 +202,8 @@ packages:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
 
-  path-to-regexp@8.3.0:
-    resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
+  path-to-regexp@8.4.0:
+    resolution: {integrity: sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==}
 
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
@@ -468,7 +471,7 @@ snapshots:
 
   parseurl@1.3.3: {}
 
-  path-to-regexp@8.3.0: {}
+  path-to-regexp@8.4.0: {}
 
   proxy-addr@2.0.7:
     dependencies:
@@ -494,7 +497,7 @@ snapshots:
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
-      path-to-regexp: 8.3.0
+      path-to-regexp: 8.4.0
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
This updates lockfiles and adds package manager overrides to force transitive path-to-regexp to 8.4.0, addressing GHSA-j3q9-mxjg-w52f and GHSA-27v5-c462-wpq7.