### PR TITLE
Support multiple OpenAI-compatible upstream endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ If you point Ollama at a local host such as `http://127.0.0.1:11434`, modelrelay
 modelrelay supports configuring multiple OpenAI-compatible upstream endpoints (vLLM, llama.cpp, custom relays, etc.). Each endpoint exposes a single model id and is routed independently.
 
 - In the Web UI, click `+ Add Endpoint` under the **OpenAI-Compatible endpoints** group, supply a name, base URL, model id, and optional API key. Each endpoint then gets its own provider row with status, ping, and rate-limit information.
+- modelrelay automatically probes `/v1/models` on each endpoint and exposes every returned model as a routable row. The manually configured model id (if any) is merged in as a fallback. Discovery is on by default and can be toggled per-endpoint with the **"Discover models from `/v1/models`"** checkbox.
 - Endpoints are stored in `~/.modelrelay.json` under composite keys like `openai-compatible:my-vllm`:
   ```jsonc
   {

--- a/README.md
+++ b/README.md
@@ -227,6 +227,28 @@ If you leave the Ollama base URL blank in the UI, modelrelay defaults to `https:
 With a valid Ollama API key, modelrelay will discover available Ollama models automatically.
 If you point Ollama at a local host such as `http://127.0.0.1:11434`, modelrelay will also auto-discover models and does not require an API key.
 
+### OpenAI-Compatible endpoints
+
+modelrelay supports configuring multiple OpenAI-compatible upstream endpoints (vLLM, llama.cpp, custom relays, etc.). Each endpoint exposes a single model id and is routed independently.
+
+- In the Web UI, click `+ Add Endpoint` under the **OpenAI-Compatible endpoints** group, supply a name, base URL, model id, and optional API key. Each endpoint then gets its own provider row with status, ping, and rate-limit information.
+- Endpoints are stored in `~/.modelrelay.json` under composite keys like `openai-compatible:my-vllm`:
+  ```jsonc
+  {
+    "apiKeys": {
+      "openai-compatible:my-vllm": "sk-…",
+      "openai-compatible:groq-clone": "sk-…"
+    },
+    "providers": {
+      "openai-compatible:my-vllm":    { "enabled": true, "name": "Local vLLM", "baseUrl": "http://localhost:8000/v1", "modelId": "qwen-coder" },
+      "openai-compatible:groq-clone": { "enabled": true, "name": "Groq Clone", "baseUrl": "https://example/v1",        "modelId": "llama-3.3-70b" }
+    }
+  }
+  ```
+- Legacy single-endpoint configs (a bare `openai-compatible` entry without an instance suffix) are migrated automatically to `openai-compatible:default` on first run.
+- The legacy env vars `OPENAI_COMPATIBLE_API_KEY` / `OPENAI_COMPATIBLE_BASE_URL` / `OPENAI_COMPATIBLE_MODEL` continue to work and apply to the `:default` instance.
+- Endpoints can also be managed via the API: `POST /api/openai-compatible/endpoints` (body: `{name, baseUrl, modelId, apiKey?}`) and `DELETE /api/openai-compatible/endpoints/<id>`.
+
 ### Config migration (CLI + Web UI)
 
 - In the Web UI, open `Settings` -> `Configuration Transfer` to export/copy/import a token.

--- a/lib/config.js
+++ b/lib/config.js
@@ -310,6 +310,7 @@ export function listOpenAICompatibleEndpoints(config) {
       modelId: getProviderModelId(config, key) || '',
       apiKey: getApiKey(config, key),
       enabled: p.enabled !== false,
+      discoverModels: p.discoverModels !== false,
     })
   }
 
@@ -329,6 +330,7 @@ export function listOpenAICompatibleEndpoints(config) {
         modelId: envModelId || '',
         apiKey: envApiKey,
         enabled: true,
+        discoverModels: true,
       })
     }
   }
@@ -357,6 +359,10 @@ export function upsertOpenAICompatibleEndpoint(config, fields) {
   if (fields.baseUrl !== undefined) merged.baseUrl = normalizeText(fields.baseUrl)
   if (fields.modelId !== undefined) merged.modelId = normalizeText(fields.modelId)
   if (fields.enabled !== undefined) merged.enabled = fields.enabled !== false
+  if (fields.discoverModels !== undefined) {
+    if (fields.discoverModels === false) merged.discoverModels = false
+    else delete merged.discoverModels
+  }
   config.providers[instanceKey] = merged
 
   if (fields.apiKey !== undefined) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -57,6 +57,33 @@ import { join } from 'path'
 export const CONFIG_PATH = join(homedir(), '.modelrelay.json')
 const CONFIG_TRANSFER_PREFIX = 'mrconf:v1:'
 
+// 📖 OpenAI-compatible multi-instance support
+// 📖 Each endpoint is keyed as `openai-compatible:<id>` (e.g. `openai-compatible:default`).
+// 📖 The bare `openai-compatible` provider key is a template only and is migrated to `:default`.
+export const OPENAI_COMPATIBLE_PROVIDER_KEY = 'openai-compatible'
+const OPENAI_COMPATIBLE_INSTANCE_PREFIX = `${OPENAI_COMPATIBLE_PROVIDER_KEY}:`
+const DEFAULT_OPENAI_COMPATIBLE_INSTANCE_ID = 'default'
+
+export function isOpenAICompatibleInstanceKey(providerKey) {
+  return typeof providerKey === 'string' && providerKey.startsWith(OPENAI_COMPATIBLE_INSTANCE_PREFIX)
+}
+
+export function getBaseProviderKey(providerKey) {
+  if (isOpenAICompatibleInstanceKey(providerKey)) return OPENAI_COMPATIBLE_PROVIDER_KEY
+  return providerKey
+}
+
+export function getOpenAICompatibleInstanceId(providerKey) {
+  if (!isOpenAICompatibleInstanceKey(providerKey)) return null
+  return providerKey.slice(OPENAI_COMPATIBLE_INSTANCE_PREFIX.length)
+}
+
+export function buildOpenAICompatibleInstanceKey(id) {
+  const trimmed = String(id || '').trim().toLowerCase().replace(/[^a-z0-9_-]+/g, '-').replace(/^-+|-+$/g, '')
+  if (!trimmed) return null
+  return `${OPENAI_COMPATIBLE_INSTANCE_PREFIX}${trimmed}`
+}
+
 // 📖 Environment variable names per provider
 // 📖 These allow users to override config via env vars (useful for CI/headless setups)
 const ENV_VARS = {
@@ -173,7 +200,7 @@ export function importConfigToken(token) {
  */
 export function getApiKey(config, providerKey) {
   // 📖 Env var override — takes precedence over everything
-  const envVar = ENV_VARS[providerKey]
+  const envVar = ENV_VARS[providerKey] || _legacyOpenAICompatibleEnvVar(providerKey, ENV_VARS)
   if (envVar && process.env[envVar]) {
     return normalizeSecret(process.env[envVar]);
   }
@@ -192,7 +219,7 @@ export function getApiKey(config, providerKey) {
  * @returns {string[]}
  */
 export function getApiKeyPool(config, providerKey) {
-  const envVar = ENV_VARS[providerKey]
+  const envVar = ENV_VARS[providerKey] || _legacyOpenAICompatibleEnvVar(providerKey, ENV_VARS)
   if (envVar && process.env[envVar]) {
     const k = normalizeSecret(process.env[envVar])
     return k ? [k] : []
@@ -230,7 +257,7 @@ export function getMaxTurns(config, providerKey) {
 }
 
 export function getProviderBaseUrl(config, providerKey) {
-  const envVar = PROVIDER_BASE_URL_ENV_VARS[providerKey]
+  const envVar = PROVIDER_BASE_URL_ENV_VARS[providerKey] || _legacyOpenAICompatibleEnvVar(providerKey, PROVIDER_BASE_URL_ENV_VARS)
   if (envVar && process.env[envVar]) {
     return normalizeText(process.env[envVar]) || null
   }
@@ -240,13 +267,128 @@ export function getProviderBaseUrl(config, providerKey) {
 }
 
 export function getProviderModelId(config, providerKey) {
-  const envVar = PROVIDER_MODEL_ID_ENV_VARS[providerKey]
+  const envVar = PROVIDER_MODEL_ID_ENV_VARS[providerKey] || _legacyOpenAICompatibleEnvVar(providerKey, PROVIDER_MODEL_ID_ENV_VARS)
   if (envVar && process.env[envVar]) {
     return normalizeText(process.env[envVar]) || null
   }
 
   const modelId = config?.providers?.[providerKey]?.modelId
   return normalizeText(modelId) || null
+}
+
+// 📖 Legacy OPENAI_COMPATIBLE_* env vars apply to the `:default` instance.
+function _legacyOpenAICompatibleEnvVar(providerKey, envMap) {
+  if (providerKey === `${OPENAI_COMPATIBLE_INSTANCE_PREFIX}${DEFAULT_OPENAI_COMPATIBLE_INSTANCE_ID}`) {
+    return envMap[OPENAI_COMPATIBLE_PROVIDER_KEY] || null
+  }
+  return null
+}
+
+/**
+ * 📖 listOpenAICompatibleEndpoints: Return all configured OpenAI-compatible endpoints.
+ *
+ * Walks `config.providers` for keys that start with `openai-compatible:` and pairs them
+ * with their api keys from `config.apiKeys`. Stable insertion order.
+ *
+ * @param {object} config
+ * @returns {Array<{instanceKey:string,id:string,name:string,baseUrl:string,modelId:string,apiKey:string|null,enabled:boolean}>}
+ */
+export function listOpenAICompatibleEndpoints(config) {
+  const providers = (config && config.providers && typeof config.providers === 'object') ? config.providers : {}
+  const out = []
+  const defaultKey = `${OPENAI_COMPATIBLE_INSTANCE_PREFIX}${DEFAULT_OPENAI_COMPATIBLE_INSTANCE_ID}`
+  let sawDefault = false
+  for (const key of Object.keys(providers)) {
+    if (!isOpenAICompatibleInstanceKey(key)) continue
+    if (key === defaultKey) sawDefault = true
+    const p = providers[key] || {}
+    out.push({
+      instanceKey: key,
+      id: getOpenAICompatibleInstanceId(key),
+      name: normalizeText(p.name) || getOpenAICompatibleInstanceId(key),
+      baseUrl: getProviderBaseUrl(config, key) || '',
+      modelId: getProviderModelId(config, key) || '',
+      apiKey: getApiKey(config, key),
+      enabled: p.enabled !== false,
+    })
+  }
+
+  // 📖 Surface a virtual `:default` instance when only the legacy env vars
+  // 📖 OPENAI_COMPATIBLE_* are set (no JSON entry). Keeps the UI consistent
+  // 📖 with prior behavior where env-var-only users still saw the provider row.
+  if (!sawDefault) {
+    const envBaseUrl = getProviderBaseUrl(config, defaultKey)
+    const envModelId = getProviderModelId(config, defaultKey)
+    const envApiKey = getApiKey(config, defaultKey)
+    if (envBaseUrl || envModelId || envApiKey) {
+      out.push({
+        instanceKey: defaultKey,
+        id: DEFAULT_OPENAI_COMPATIBLE_INSTANCE_ID,
+        name: 'Default',
+        baseUrl: envBaseUrl || '',
+        modelId: envModelId || '',
+        apiKey: envApiKey,
+        enabled: true,
+      })
+    }
+  }
+  return out
+}
+
+/**
+ * 📖 upsertOpenAICompatibleEndpoint: Add or update an endpoint instance in-place.
+ *
+ * @param {object} config
+ * @param {{id?:string, instanceKey?:string, name?:string, baseUrl?:string, modelId?:string, apiKey?:string|null, enabled?:boolean}} fields
+ * @returns {string} the instanceKey written
+ */
+export function upsertOpenAICompatibleEndpoint(config, fields) {
+  if (!config || typeof config !== 'object') throw new Error('config required')
+  if (!config.apiKeys || typeof config.apiKeys !== 'object') config.apiKeys = {}
+  if (!config.providers || typeof config.providers !== 'object') config.providers = {}
+
+  let instanceKey = fields?.instanceKey
+  if (!instanceKey) instanceKey = buildOpenAICompatibleInstanceKey(fields?.id || fields?.name || '')
+  if (!instanceKey) throw new Error('endpoint id or name required')
+
+  const existing = config.providers[instanceKey] || {}
+  const merged = { ...existing }
+  if (fields.name !== undefined) merged.name = normalizeText(fields.name)
+  if (fields.baseUrl !== undefined) merged.baseUrl = normalizeText(fields.baseUrl)
+  if (fields.modelId !== undefined) merged.modelId = normalizeText(fields.modelId)
+  if (fields.enabled !== undefined) merged.enabled = fields.enabled !== false
+  config.providers[instanceKey] = merged
+
+  if (fields.apiKey !== undefined) {
+    if (fields.apiKey === null || fields.apiKey === '') {
+      delete config.apiKeys[instanceKey]
+    } else {
+      config.apiKeys[instanceKey] = normalizeSecret(fields.apiKey)
+    }
+  }
+
+  return instanceKey
+}
+
+/**
+ * 📖 removeOpenAICompatibleEndpoint: Delete an endpoint instance and its API key entry.
+ *
+ * @param {object} config
+ * @param {string} instanceKey
+ * @returns {boolean} true if anything was removed
+ */
+export function removeOpenAICompatibleEndpoint(config, instanceKey) {
+  if (!isOpenAICompatibleInstanceKey(instanceKey)) return false
+  let removed = false
+  if (config?.providers && instanceKey in config.providers) {
+    delete config.providers[instanceKey]
+    removed = true
+  }
+  if (config?.apiKeys && instanceKey in config.apiKeys) {
+    delete config.apiKeys[instanceKey]
+    removed = true
+  }
+  return removed
 }
 
 /**
@@ -370,7 +512,51 @@ export function normalizeConfigShape(config) {
     if (typeof providerConfig.modelId === 'string') {
       providerConfig.modelId = normalizeText(providerConfig.modelId)
     }
+    if (typeof providerConfig.name === 'string') {
+      providerConfig.name = normalizeText(providerConfig.name)
+    }
   }
 
+  _migrateLegacyOpenAICompatible(base)
+
   return base
+}
+
+// 📖 Legacy single-instance config (`openai-compatible` provider key with baseUrl/modelId
+// 📖 fields, and apiKey at apiKeys['openai-compatible']) is migrated to the canonical
+// 📖 instance key `openai-compatible:default`. The bare key is stripped after migration.
+function _migrateLegacyOpenAICompatible(base) {
+  const legacyProvider = base.providers[OPENAI_COMPATIBLE_PROVIDER_KEY]
+  const legacyKey = base.apiKeys[OPENAI_COMPATIBLE_PROVIDER_KEY]
+  const hasLegacyConfig =
+    (legacyProvider && (legacyProvider.baseUrl || legacyProvider.modelId || legacyProvider.enabled === false || legacyProvider.maxTurns)) ||
+    (legacyKey && (typeof legacyKey === 'string' ? legacyKey.trim() : (Array.isArray(legacyKey) && legacyKey.length > 0)))
+
+  if (!hasLegacyConfig) {
+    // Drop empty bare entry if present so it doesn't shadow lookups.
+    delete base.providers[OPENAI_COMPATIBLE_PROVIDER_KEY]
+    delete base.apiKeys[OPENAI_COMPATIBLE_PROVIDER_KEY]
+    return
+  }
+
+  const targetKey = `${OPENAI_COMPATIBLE_INSTANCE_PREFIX}${DEFAULT_OPENAI_COMPATIBLE_INSTANCE_ID}`
+  // Don't clobber an explicit :default the user has already configured.
+  if (base.providers[targetKey] || base.apiKeys[targetKey]) {
+    delete base.providers[OPENAI_COMPATIBLE_PROVIDER_KEY]
+    delete base.apiKeys[OPENAI_COMPATIBLE_PROVIDER_KEY]
+    return
+  }
+
+  if (legacyProvider) {
+    const merged = { ...legacyProvider }
+    if (!merged.name) merged.name = 'Default'
+    base.providers[targetKey] = merged
+  } else {
+    base.providers[targetKey] = { name: 'Default' }
+  }
+
+  if (legacyKey != null) base.apiKeys[targetKey] = legacyKey
+
+  delete base.providers[OPENAI_COMPATIBLE_PROVIDER_KEY]
+  delete base.apiKeys[OPENAI_COMPATIBLE_PROVIDER_KEY]
 }

--- a/lib/server.js
+++ b/lib/server.js
@@ -38,6 +38,7 @@ const OPENCODE_MODELS_URL = 'https://opencode.ai/zen/v1/models';
 const OPENCODE_MODELS_REFRESH_MS = 60 * 60_000;
 
 const OPENAI_COMPATIBLE_PROVIDER_KEY = 'openai-compatible';
+const OPENAI_COMPATIBLE_MODELS_REFRESH_MS = 30 * 60_000;
 const OLLAMA_PROVIDER_KEY = 'ollama';
 const OLLAMA_MODELS_REFRESH_MS = 60 * 60_000;
 const OPENROUTER_PROVIDER_KEY = 'openrouter';
@@ -1052,6 +1053,7 @@ export async function runServer(config, port, enableLog = true, bannedModels = [
   let lastOpenCodeModelRefreshAt = 0;
   let lastOllamaModelRefreshAt = 0;
   let lastOpenRouterModelRefreshAt = 0;
+  const lastOpenAICompatibleDiscoveryAt = new Map();
 
   const reindexResults = () => {
     for (let i = 0; i < results.length; i += 1) {
@@ -1150,7 +1152,7 @@ export async function runServer(config, port, enableLog = true, bannedModels = [
     }
   };
 
-  const refreshOpenAICompatibleModels = async (onlyInstanceKey = null) => {
+  const refreshOpenAICompatibleModels = async (onlyInstanceKey = null, force = false) => {
     const currentConfig = loadConfig();
     const endpoints = listOpenAICompatibleEndpoints(currentConfig);
     const instanceKeys = new Set(endpoints.map(e => e.instanceKey));
@@ -1161,9 +1163,13 @@ export async function runServer(config, port, enableLog = true, bannedModels = [
         .filter(r => isOpenAICompatibleInstanceKey(r.providerKey) && !instanceKeys.has(r.providerKey))
         .map(r => r.providerKey)
     );
-    for (const ok of orphaned) mergeDynamicProviderModels(ok, []);
+    for (const ok of orphaned) {
+      mergeDynamicProviderModels(ok, []);
+      lastOpenAICompatibleDiscoveryAt.delete(ok);
+    }
 
     const refreshed = [];
+    const now = Date.now();
     for (const ep of endpoints) {
       if (onlyInstanceKey && ep.instanceKey !== onlyInstanceKey) continue;
       if (!ep.enabled) {
@@ -1172,13 +1178,33 @@ export async function runServer(config, port, enableLog = true, bannedModels = [
       }
 
       const fallbackModel = buildOpenAICompatibleModelMeta(currentConfig, ep.instanceKey);
+      const discoveryEnabled = isOpenAICompatibleDiscoveryEnabled(currentConfig, ep.instanceKey);
+      const lastDiscoveredAt = lastOpenAICompatibleDiscoveryAt.get(ep.instanceKey) || 0;
+      const ttlExpired = (now - lastDiscoveredAt) >= OPENAI_COMPATIBLE_MODELS_REFRESH_MS;
+      const shouldDiscover = discoveryEnabled && (force || ttlExpired);
+
       let discovered = [];
-      if (isOpenAICompatibleDiscoveryEnabled(currentConfig, ep.instanceKey)) {
+      if (shouldDiscover) {
         try {
           discovered = await fetchOpenAICompatibleDiscoveredModels(currentConfig, ep.instanceKey);
+          lastOpenAICompatibleDiscoveryAt.set(ep.instanceKey, Date.now());
         } catch (err) {
           console.log(chalk.dim(`  [OpenAI-Compatible:${ep.id}] Model discovery skipped: ${describeSyncError(err)}`));
         }
+      } else if (discoveryEnabled) {
+        // 📖 Within the TTL window: keep the previously-discovered rows visible
+        // 📖 instead of dropping them when this refresh path was just a ping cycle.
+        discovered = results
+          .filter(r => r.providerKey === ep.instanceKey)
+          .map(r => ({
+            modelId: r.modelId,
+            label: r.label,
+            intell: r.intell,
+            isEstimatedScore: r.isEstimatedScore,
+            ctx: r.ctx,
+            providerKey: ep.instanceKey,
+            providerUrl: r.providerUrl,
+          }));
       }
 
       // Merge fallback (manually-configured modelId) with discovered list, de-duped.
@@ -1229,8 +1255,8 @@ export async function runServer(config, port, enableLog = true, bannedModels = [
     if (providerKey === KILOCODE_PROVIDER_KEY) return await refreshKiloCodeModels(true);
     if (providerKey === OPENCODE_PROVIDER_KEY) return await refreshOpenCodeModels(true);
     if (providerKey === OPENROUTER_PROVIDER_KEY) return await refreshOpenRouterModels(true);
-    if (isOpenAICompatibleInstanceKey(providerKey)) return await refreshOpenAICompatibleModels(providerKey);
-    if (providerKey === OPENAI_COMPATIBLE_PROVIDER_KEY) return await refreshOpenAICompatibleModels();
+    if (isOpenAICompatibleInstanceKey(providerKey)) return await refreshOpenAICompatibleModels(providerKey, true);
+    if (providerKey === OPENAI_COMPATIBLE_PROVIDER_KEY) return await refreshOpenAICompatibleModels(null, true);
     if (providerKey === OLLAMA_PROVIDER_KEY) return await refreshOllamaModels(true);
 
     return results
@@ -1382,9 +1408,9 @@ export async function runServer(config, port, enableLog = true, bannedModels = [
       await refreshOpenRouterModels(true);
     }
     if (isOpenAICompatibleInstanceKey(providerKey)) {
-      await refreshOpenAICompatibleModels(providerKey);
+      await refreshOpenAICompatibleModels(providerKey, true);
     } else if (providerKey === OPENAI_COMPATIBLE_PROVIDER_KEY) {
-      await refreshOpenAICompatibleModels();
+      await refreshOpenAICompatibleModels(null, true);
     }
     if (providerKey === OLLAMA_PROVIDER_KEY) {
       await refreshOllamaModels(true);
@@ -1518,7 +1544,7 @@ export async function runServer(config, port, enableLog = true, bannedModels = [
   process.stdout.write(chalk.dim('  ⏳ Initializing model health checks... '));
   await safeRefreshProviderModels(() => refreshKiloCodeModels(true));
   await safeRefreshProviderModels(() => refreshOpenRouterModels(true));
-  await safeRefreshProviderModels(() => refreshOpenAICompatibleModels());
+  await safeRefreshProviderModels(() => refreshOpenAICompatibleModels(null, true));
   await safeRefreshProviderModels(() => refreshOllamaModels(true));
   await Promise.all(results.map(r => pingModel(r)));
   console.log(chalk.green('Done!'));

--- a/lib/server.js
+++ b/lib/server.js
@@ -7,7 +7,7 @@ import { homedir } from 'os';
 import { MODELS, sources, canonicalizeModelId, getPreferredModelContext, getPreferredModelLabel, getScore, resolveAliasedModelId } from '../sources.js';
 import { API_KEY_SIGNUP_URLS } from './providerLinks.js';
 import { getApiKey, getApiKeyPool, getMaxTurns, getPinningMode, getProviderBaseUrl, getProviderModelId, hasMultipleKeys, isProviderEnabled, getProviderPingIntervalMs, isAutoPingEnabled, loadConfig, saveConfig, exportConfigToken, importConfigToken, isOpenAICompatibleInstanceKey, getBaseProviderKey, listOpenAICompatibleEndpoints, upsertOpenAICompatibleEndpoint, removeOpenAICompatibleEndpoint, buildOpenAICompatibleInstanceKey, getOpenAICompatibleInstanceId } from './config.js';
-import { buildModelGroups, computeQoSMap, findBestModel, getAvg, getUptime, getVerdict, isRetryableProxyStatus, rankModelsForRouting, parseOpenRouterKeyRateLimit, filterModelsByRequested, selectNextApiKeyFromPool } from './utils.js';
+import { buildModelGroups, computeQoSMap, findBestModel, getAvg, getUptime, getVerdict, isRetryableProxyStatus, rankModelsForRouting, getRoutingModelKey, parseOpenRouterKeyRateLimit, filterModelsByRequested, selectNextApiKeyFromPool } from './utils.js';
 import { getPreferredLanIpv4Address } from './network.js';
 import { createHash, randomUUID } from 'crypto';
 import { getAutostartStatus } from './autostart.js';
@@ -124,10 +124,10 @@ export function getPinnedModelMatches(results, pinnedModelId, pinningMode = 'can
   return matchedGroup ? matchedGroup.models : results.filter(r => r.modelId === pinnedModelId);
 }
 
-export function getPinnedModelCandidate(results, pinnedModelId, pinningMode = 'canonical', attemptedModelIds = [], pinnedProviderKey = null) {
-  const attempted = new Set(attemptedModelIds);
+export function getPinnedModelCandidate(results, pinnedModelId, pinningMode = 'canonical', attemptedModelKeys = [], pinnedProviderKey = null) {
+  const attempted = new Set(attemptedModelKeys);
   const matches = getPinnedModelMatches(results, pinnedModelId, pinningMode, pinnedProviderKey)
-    .filter(r => r.status !== 'banned' && r.status !== 'disabled' && !attempted.has(r.modelId));
+    .filter(r => r.status !== 'banned' && r.status !== 'disabled' && !attempted.has(getRoutingModelKey(r)) && !attempted.has(r.modelId));
   const ranked = rankModelsForRouting(matches, Array.from(attempted));
   return ranked[0] || null;
 }
@@ -2278,7 +2278,7 @@ export async function runServer(config, port, enableLog = true, bannedModels = [
     let logEntry = null;
     try {
       const payload = req.body;
-      const attemptedModelIds = new Set();
+      const attemptedModelKeys = new Set();
       const attempts = [];
       const requestedModels = filterModelsByRequested(results, payload.model, canonicalizeModelId);
 
@@ -2289,13 +2289,13 @@ export async function runServer(config, port, enableLog = true, bannedModels = [
       const pickNextModel = () => {
         if (pinnedModelId) {
           const pinningMode = getPinningMode(loadConfig());
-          const pinned = getPinnedModelCandidate(results, pinnedModelId, pinningMode, Array.from(attemptedModelIds), pinnedProviderKey);
+          const pinned = getPinnedModelCandidate(results, pinnedModelId, pinningMode, Array.from(attemptedModelKeys), pinnedProviderKey);
           if (pinned) {
             return pinned;
           }
         }
 
-        const ranked = rankModelsForRouting(requestedModels, Array.from(attemptedModelIds));
+        const ranked = rankModelsForRouting(requestedModels, Array.from(attemptedModelKeys));
         return ranked[0] || null;
       };
 
@@ -2342,7 +2342,7 @@ export async function runServer(config, port, enableLog = true, bannedModels = [
         const best = pickNextModel();
         if (!best) break;
 
-        attemptedModelIds.add(best.modelId);
+        attemptedModelKeys.add(getRoutingModelKey(best));
         payload.model = best.modelId;
 
         const currentConfig = loadConfig();

--- a/lib/server.js
+++ b/lib/server.js
@@ -280,6 +280,14 @@ export function shouldRetryOptionalProviderWithBearer(config, providerKey, auth,
 }
 
 function normalizeOpenAICompatibleProviderUrl(resourceUrl) {
+  return buildOpenAICompatibleResourceUrl(resourceUrl, '/chat/completions');
+}
+
+export function buildOpenAICompatibleModelsListUrl(resourceUrl) {
+  return buildOpenAICompatibleResourceUrl(resourceUrl, '/models');
+}
+
+function buildOpenAICompatibleResourceUrl(resourceUrl, suffix) {
   if (!resourceUrl || typeof resourceUrl !== 'string') return null;
   const trimmed = resourceUrl.trim();
   if (!trimmed) return null;
@@ -291,18 +299,22 @@ function normalizeOpenAICompatibleProviderUrl(resourceUrl) {
 
   try {
     const parsed = new URL(urlText);
-    const pathname = (parsed.pathname || '/').replace(/\/+$/, '');
+    let pathname = (parsed.pathname || '/').replace(/\/+$/, '');
 
+    // 📖 If the configured URL already names a specific OpenAI v1 verb,
+    // 📖 strip it so `suffix` lands at the v1 root.
     if (pathname.endsWith('/chat/completions')) {
-      parsed.pathname = pathname;
-      return parsed.toString();
+      pathname = pathname.slice(0, -'/chat/completions'.length);
+    } else if (pathname.endsWith('/models')) {
+      pathname = pathname.slice(0, -'/models'.length);
     }
+
     if (pathname.endsWith('/v1')) {
-      parsed.pathname = pathname + '/chat/completions';
+      parsed.pathname = pathname + suffix;
       return parsed.toString();
     }
 
-    parsed.pathname = (pathname === '' ? '' : pathname) + '/v1/chat/completions';
+    parsed.pathname = (pathname === '' ? '' : pathname) + '/v1' + suffix;
     return parsed.toString();
   } catch {
     return null;
@@ -500,6 +512,92 @@ export function extractOpenCodeModelRecords(payload) {
   if (!payload || typeof payload !== 'object') return [];
   if (Array.isArray(payload.data)) return payload.data;
   return [];
+}
+
+export function extractOpenAICompatibleModelRecords(payload) {
+  if (Array.isArray(payload)) return payload;
+  if (!payload || typeof payload !== 'object') return [];
+  if (Array.isArray(payload.data)) return payload.data;
+  if (Array.isArray(payload.models)) return payload.models;
+  return [];
+}
+
+export function toOpenAICompatibleDiscoveredModelMeta(record, instanceKey, providerUrl = null) {
+  const modelId = typeof record === 'string'
+    ? record.trim()
+    : String(record?.id || record?.model || record?.name || '').trim();
+  if (!modelId) return null;
+  if (isExcludedDynamicModelId(modelId)) return null;
+
+  const scoreLookupId = resolveAliasedModelId(modelId);
+  const { base, unprefixed } = canonicalizeModelId(scoreLookupId);
+  const known = knownModelMetaMap.get(scoreLookupId)
+    || knownModelMetaMap.get(base)
+    || knownModelMetaMap.get(unprefixed)
+    || knownModelMetaMap.get(modelId)
+    || null;
+  const knownScore = normalizeIntelligenceScore(getScore(scoreLookupId));
+  const hasScore = (knownScore != null && knownScore > 0) || (known != null && known.intell != null);
+
+  const recordLabel = (record && typeof record === 'object' && typeof record.name === 'string' && record.name.trim())
+    ? record.name.trim()
+    : null;
+  const label = getPreferredModelLabel(scoreLookupId, recordLabel || known?.label || formatGenericProviderModelLabel(modelId));
+
+  const ctxRaw = record && typeof record === 'object'
+    ? (record.context_length ?? record.contextLength ?? record.ctx ?? null)
+    : null;
+  const ctx = parseKiloCodeContext(ctxRaw) || known?.ctx || DEFAULT_DYNAMIC_MODEL_CTX;
+
+  return {
+    modelId,
+    label,
+    intell: knownScore ?? known?.intell ?? DEFAULT_DYNAMIC_MODEL_INTELL,
+    isEstimatedScore: !hasScore,
+    ctx,
+    providerKey: instanceKey,
+    providerUrl: providerUrl || undefined,
+  };
+}
+
+export async function fetchOpenAICompatibleDiscoveredModels(config, instanceKey) {
+  const baseUrl = getProviderBaseUrl(config, instanceKey);
+  if (!baseUrl) return [];
+  const modelsUrl = buildOpenAICompatibleModelsListUrl(baseUrl);
+  if (!modelsUrl) return [];
+
+  const headers = { Accept: 'application/json' };
+  const apiKey = getApiKey(config, instanceKey);
+  if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+
+  const ctrl = new AbortController();
+  const timeoutId = setTimeout(() => ctrl.abort(), PING_TIMEOUT);
+  try {
+    const response = await fetch(modelsUrl, { method: 'GET', headers, signal: ctrl.signal });
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+    const payload = await response.json();
+    const records = extractOpenAICompatibleModelRecords(payload);
+    const seen = new Set();
+    const models = [];
+    const chatUrl = normalizeOpenAICompatibleProviderUrl(baseUrl);
+    for (const record of records) {
+      const model = toOpenAICompatibleDiscoveredModelMeta(record, instanceKey, chatUrl);
+      if (!model || seen.has(model.modelId)) continue;
+      seen.add(model.modelId);
+      models.push(model);
+    }
+    return models;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+function isOpenAICompatibleDiscoveryEnabled(config, instanceKey) {
+  const providerConfig = config?.providers?.[instanceKey];
+  if (!providerConfig) return true;
+  return providerConfig.discoverModels !== false;
 }
 
 export function toOllamaModelMeta(record) {
@@ -1072,9 +1170,23 @@ export async function runServer(config, port, enableLog = true, bannedModels = [
         mergeDynamicProviderModels(ep.instanceKey, []);
         continue;
       }
-      const model = buildOpenAICompatibleModelMeta(currentConfig, ep.instanceKey);
-      mergeDynamicProviderModels(ep.instanceKey, model ? [model] : []);
-      if (model) refreshed.push(model);
+
+      const fallbackModel = buildOpenAICompatibleModelMeta(currentConfig, ep.instanceKey);
+      let discovered = [];
+      if (isOpenAICompatibleDiscoveryEnabled(currentConfig, ep.instanceKey)) {
+        try {
+          discovered = await fetchOpenAICompatibleDiscoveredModels(currentConfig, ep.instanceKey);
+        } catch (err) {
+          console.log(chalk.dim(`  [OpenAI-Compatible:${ep.id}] Model discovery skipped: ${describeSyncError(err)}`));
+        }
+      }
+
+      // Merge fallback (manually-configured modelId) with discovered list, de-duped.
+      const merged = fallbackModel
+        ? [fallbackModel, ...discovered.filter(m => m.modelId !== fallbackModel.modelId)]
+        : discovered;
+      mergeDynamicProviderModels(ep.instanceKey, merged);
+      refreshed.push(...merged);
     }
     return refreshed;
   };
@@ -1507,6 +1619,7 @@ export async function runServer(config, port, enableLog = true, bannedModels = [
       modelId: supportsBaseUrlAndModelId ? (getProviderModelId(currentConfig, key) || '') : null,
       isOpenAICompatibleInstance: isOaiInstance,
       openAICompatibleInstanceId: isOaiInstance ? getOpenAICompatibleInstanceId(key) : null,
+      discoverModels: isOaiInstance ? (currentConfig.providers?.[key]?.discoverModels !== false) : null,
       hasMultipleKeys: hasMultiple,
       maxTurns: getMaxTurns(currentConfig, key),
       apiKeyPool: pool.map((k, i) => {
@@ -1531,7 +1644,7 @@ export async function runServer(config, port, enableLog = true, bannedModels = [
   });
 
   app.post('/api/openai-compatible/endpoints', (req, res) => {
-    const { id, name, baseUrl, modelId, apiKey, enabled } = req.body || {};
+    const { id, name, baseUrl, modelId, apiKey, enabled, discoverModels } = req.body || {};
     if (!name && !id) return res.status(400).json({ error: 'name or id is required.' });
 
     const currentConfig = loadConfig();
@@ -1548,6 +1661,7 @@ export async function runServer(config, port, enableLog = true, bannedModels = [
       modelId: modelId || '',
       apiKey: apiKey === undefined ? undefined : apiKey,
       enabled: enabled !== false,
+      discoverModels: discoverModels === undefined ? undefined : (discoverModels !== false),
     });
     saveConfig(currentConfig);
 
@@ -1794,7 +1908,7 @@ export async function runServer(config, port, enableLog = true, bannedModels = [
   });
 
   app.post('/api/config', (req, res) => {
-    const { providerKey, apiKey, enabled, useBearerAuth, pingIntervalMinutes, baseUrl, modelId, pinningMode, maxTurns, apiKeys } = req.body;
+    const { providerKey, apiKey, enabled, useBearerAuth, pingIntervalMinutes, baseUrl, modelId, pinningMode, maxTurns, apiKeys, discoverModels } = req.body;
     const currentConfig = loadConfig();
     const wasEnabled = isProviderEnabled(currentConfig, providerKey);
 
@@ -1843,6 +1957,13 @@ export async function runServer(config, port, enableLog = true, bannedModels = [
       else currentConfig.providers[providerKey].modelId = String(modelId).trim();
     }
 
+    if (discoverModels !== undefined && isOpenAICompatibleInstanceKey(providerKey)) {
+      if (!currentConfig.providers) currentConfig.providers = {};
+      if (!currentConfig.providers[providerKey]) currentConfig.providers[providerKey] = {};
+      if (discoverModels === false) currentConfig.providers[providerKey].discoverModels = false;
+      else delete currentConfig.providers[providerKey].discoverModels;
+    }
+
     if (pingIntervalMinutes !== undefined) {
       if (!currentConfig.providers) currentConfig.providers = {};
       if (!currentConfig.providers[providerKey]) currentConfig.providers[providerKey] = {};
@@ -1882,7 +2003,7 @@ export async function runServer(config, port, enableLog = true, bannedModels = [
       void triggerImmediateProviderPing(providerKey);
     } else if (providerKey === OPENROUTER_PROVIDER_KEY && apiKey !== undefined) {
       void triggerImmediateProviderPing(providerKey);
-    } else if ((isOpenAICompatibleInstanceKey(providerKey) || providerKey === OPENAI_COMPATIBLE_PROVIDER_KEY || providerKey === OLLAMA_PROVIDER_KEY) && (apiKey !== undefined || baseUrl !== undefined || modelId !== undefined)) {
+    } else if ((isOpenAICompatibleInstanceKey(providerKey) || providerKey === OPENAI_COMPATIBLE_PROVIDER_KEY || providerKey === OLLAMA_PROVIDER_KEY) && (apiKey !== undefined || baseUrl !== undefined || modelId !== undefined || discoverModels !== undefined)) {
       void triggerImmediateProviderPing(providerKey);
     }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -6,7 +6,7 @@ import { readFileSync, writeFileSync, existsSync } from 'fs';
 import { homedir } from 'os';
 import { MODELS, sources, canonicalizeModelId, getPreferredModelContext, getPreferredModelLabel, getScore, resolveAliasedModelId } from '../sources.js';
 import { API_KEY_SIGNUP_URLS } from './providerLinks.js';
-import { getApiKey, getApiKeyPool, getMaxTurns, getPinningMode, getProviderBaseUrl, getProviderModelId, hasMultipleKeys, isProviderEnabled, getProviderPingIntervalMs, isAutoPingEnabled, loadConfig, saveConfig, exportConfigToken, importConfigToken } from './config.js';
+import { getApiKey, getApiKeyPool, getMaxTurns, getPinningMode, getProviderBaseUrl, getProviderModelId, hasMultipleKeys, isProviderEnabled, getProviderPingIntervalMs, isAutoPingEnabled, loadConfig, saveConfig, exportConfigToken, importConfigToken, isOpenAICompatibleInstanceKey, getBaseProviderKey, listOpenAICompatibleEndpoints, upsertOpenAICompatibleEndpoint, removeOpenAICompatibleEndpoint, buildOpenAICompatibleInstanceKey, getOpenAICompatibleInstanceId } from './config.js';
 import { buildModelGroups, computeQoSMap, findBestModel, getAvg, getUptime, getVerdict, isRetryableProxyStatus, rankModelsForRouting, parseOpenRouterKeyRateLimit, filterModelsByRequested, selectNextApiKeyFromPool } from './utils.js';
 import { getPreferredLanIpv4Address } from './network.js';
 import { createHash, randomUUID } from 'crypto';
@@ -344,8 +344,8 @@ function buildConfigurableProviderModelMeta(config, providerKey, defaultBaseUrl 
   };
 }
 
-function buildOpenAICompatibleModelMeta(config) {
-  return buildConfigurableProviderModelMeta(config, OPENAI_COMPATIBLE_PROVIDER_KEY);
+function buildOpenAICompatibleModelMeta(config, instanceKey) {
+  return buildConfigurableProviderModelMeta(config, instanceKey);
 }
 
 function buildOllamaModelMeta(config) {
@@ -849,7 +849,7 @@ async function resolveProviderAuthToken(config, providerKey, options = {}) {
 
 function resolveProviderUrl(config, providerKey, authProviderUrlOverride = null, resultProviderUrl = null) {
   if (authProviderUrlOverride) return authProviderUrlOverride;
-  if (providerKey === OPENAI_COMPATIBLE_PROVIDER_KEY || providerKey === OLLAMA_PROVIDER_KEY) {
+  if (isOpenAICompatibleInstanceKey(providerKey) || providerKey === OPENAI_COMPATIBLE_PROVIDER_KEY || providerKey === OLLAMA_PROVIDER_KEY) {
     return normalizeOpenAICompatibleProviderUrl(resultProviderUrl || getProviderBaseUrl(config, providerKey) || getDefaultProviderBaseUrl(providerKey));
   }
   return sources[providerKey]?.url || sources.nvidia.url;
@@ -1052,16 +1052,31 @@ export async function runServer(config, port, enableLog = true, bannedModels = [
     }
   };
 
-  const refreshOpenAICompatibleModels = async () => {
+  const refreshOpenAICompatibleModels = async (onlyInstanceKey = null) => {
     const currentConfig = loadConfig();
-    if (!isProviderEnabled(currentConfig, OPENAI_COMPATIBLE_PROVIDER_KEY)) {
-      mergeDynamicProviderModels(OPENAI_COMPATIBLE_PROVIDER_KEY, []);
-      return [];
-    }
+    const endpoints = listOpenAICompatibleEndpoints(currentConfig);
+    const instanceKeys = new Set(endpoints.map(e => e.instanceKey));
 
-    const model = buildOpenAICompatibleModelMeta(currentConfig);
-    mergeDynamicProviderModels(OPENAI_COMPATIBLE_PROVIDER_KEY, model ? [model] : []);
-    return model ? [model] : [];
+    // Drop result rows for instances that no longer exist.
+    const orphaned = new Set(
+      results
+        .filter(r => isOpenAICompatibleInstanceKey(r.providerKey) && !instanceKeys.has(r.providerKey))
+        .map(r => r.providerKey)
+    );
+    for (const ok of orphaned) mergeDynamicProviderModels(ok, []);
+
+    const refreshed = [];
+    for (const ep of endpoints) {
+      if (onlyInstanceKey && ep.instanceKey !== onlyInstanceKey) continue;
+      if (!ep.enabled) {
+        mergeDynamicProviderModels(ep.instanceKey, []);
+        continue;
+      }
+      const model = buildOpenAICompatibleModelMeta(currentConfig, ep.instanceKey);
+      mergeDynamicProviderModels(ep.instanceKey, model ? [model] : []);
+      if (model) refreshed.push(model);
+    }
+    return refreshed;
   };
 
   const refreshOllamaModels = async (force = false) => {
@@ -1094,13 +1109,15 @@ export async function runServer(config, port, enableLog = true, bannedModels = [
   };
 
   const refreshProviderModelsForApi = async (providerKey) => {
-    if (!providerKey || !sources[providerKey]) {
+    const baseKey = getBaseProviderKey(providerKey);
+    if (!providerKey || !sources[baseKey]) {
       throw new Error('Unknown provider.');
     }
 
     if (providerKey === KILOCODE_PROVIDER_KEY) return await refreshKiloCodeModels(true);
     if (providerKey === OPENCODE_PROVIDER_KEY) return await refreshOpenCodeModels(true);
     if (providerKey === OPENROUTER_PROVIDER_KEY) return await refreshOpenRouterModels(true);
+    if (isOpenAICompatibleInstanceKey(providerKey)) return await refreshOpenAICompatibleModels(providerKey);
     if (providerKey === OPENAI_COMPATIBLE_PROVIDER_KEY) return await refreshOpenAICompatibleModels();
     if (providerKey === OLLAMA_PROVIDER_KEY) return await refreshOllamaModels(true);
 
@@ -1252,7 +1269,9 @@ export async function runServer(config, port, enableLog = true, bannedModels = [
     if (providerKey === OPENROUTER_PROVIDER_KEY) {
       await refreshOpenRouterModels(true);
     }
-    if (providerKey === OPENAI_COMPATIBLE_PROVIDER_KEY) {
+    if (isOpenAICompatibleInstanceKey(providerKey)) {
+      await refreshOpenAICompatibleModels(providerKey);
+    } else if (providerKey === OPENAI_COMPATIBLE_PROVIDER_KEY) {
       await refreshOpenAICompatibleModels();
     }
     if (providerKey === OLLAMA_PROVIDER_KEY) {
@@ -1468,38 +1487,98 @@ export async function runServer(config, port, enableLog = true, bannedModels = [
     res.json({ models: formatted, best: effectiveBest ? effectiveBest.modelId : null, pinnedModelId, pinnedProviderKey, pinnedModelIds, pinnedRowKeys, pinningMode });
   });
 
+  const buildProviderConfigEntry = (currentConfig, key, displayName) => {
+    const baseKey = getBaseProviderKey(key);
+    const pool = getApiKeyPool(currentConfig, key)
+    const hasMultiple = pool.length > 1
+    const isOaiInstance = isOpenAICompatibleInstanceKey(key);
+    const supportsBaseUrlAndModelId = isOaiInstance || baseKey === OLLAMA_PROVIDER_KEY;
+    const sourceName = sources[baseKey]?.name || key;
+    return {
+      key,
+      name: displayName || sourceName,
+      enabled: isProviderEnabled(currentConfig, key),
+      hasKey: pool.length > 0,
+      signupUrl: API_KEY_SIGNUP_URLS[baseKey] || null,
+      supportsOptionalBearerAuth: isProviderAuthOptional(currentConfig, key),
+      useBearerAuth: isProviderAuthOptional(currentConfig, key) ? isProviderBearerAuthEnabled(currentConfig, key) : null,
+      pingIntervalMinutes: currentConfig.providers?.[key]?.pingIntervalMinutes || null,
+      baseUrl: supportsBaseUrlAndModelId ? (getProviderBaseUrl(currentConfig, key) || '') : null,
+      modelId: supportsBaseUrlAndModelId ? (getProviderModelId(currentConfig, key) || '') : null,
+      isOpenAICompatibleInstance: isOaiInstance,
+      openAICompatibleInstanceId: isOaiInstance ? getOpenAICompatibleInstanceId(key) : null,
+      hasMultipleKeys: hasMultiple,
+      maxTurns: getMaxTurns(currentConfig, key),
+      apiKeyPool: pool.map((k, i) => {
+        const masked = k.length > 8 ? `${k.slice(0, 4)}...${k.slice(-4)}` : `${k.slice(0, 2)}***`
+        return { index: i, masked, key: k }
+      }),
+    }
+  };
+
   app.get('/api/config', (req, res) => {
     const currentConfig = loadConfig();
-    const providers = Object.keys(sources).map(key => {
-      const pool = getApiKeyPool(currentConfig, key)
-      const hasMultiple = pool.length > 1
-      return {
-        key,
-        name: sources[key].name,
-        enabled: isProviderEnabled(currentConfig, key),
-        hasKey: pool.length > 0,
-        signupUrl: API_KEY_SIGNUP_URLS[key] || null,
-        supportsOptionalBearerAuth: isProviderAuthOptional(currentConfig, key),
-        useBearerAuth: isProviderAuthOptional(currentConfig, key) ? isProviderBearerAuthEnabled(currentConfig, key) : null,
-        pingIntervalMinutes: currentConfig.providers?.[key]?.pingIntervalMinutes || null,
-        baseUrl: (key === OPENAI_COMPATIBLE_PROVIDER_KEY || key === OLLAMA_PROVIDER_KEY) ? (getProviderBaseUrl(currentConfig, key) || '') : null,
-        modelId: (key === OPENAI_COMPATIBLE_PROVIDER_KEY || key === OLLAMA_PROVIDER_KEY) ? (getProviderModelId(currentConfig, key) || '') : null,
-        hasMultipleKeys: hasMultiple,
-        maxTurns: getMaxTurns(currentConfig, key),
-        apiKeyPool: pool.map((k, i) => {
-          const masked = k.length > 8 ? `${k.slice(0, 4)}...${k.slice(-4)}` : `${k.slice(0, 2)}***`
-          return { index: i, masked, key: k }
-        }),
-      }
-    });
+    const providers = [];
+    for (const key of Object.keys(sources)) {
+      // The bare 'openai-compatible' source is a template; its instances are emitted separately.
+      if (key === OPENAI_COMPATIBLE_PROVIDER_KEY) continue;
+      providers.push(buildProviderConfigEntry(currentConfig, key));
+    }
+    for (const ep of listOpenAICompatibleEndpoints(currentConfig)) {
+      providers.push(buildProviderConfigEntry(currentConfig, ep.instanceKey, ep.name));
+    }
     res.json(providers);
+  });
+
+  app.post('/api/openai-compatible/endpoints', (req, res) => {
+    const { id, name, baseUrl, modelId, apiKey, enabled } = req.body || {};
+    if (!name && !id) return res.status(400).json({ error: 'name or id is required.' });
+
+    const currentConfig = loadConfig();
+    const desiredKey = buildOpenAICompatibleInstanceKey(id || name);
+    if (!desiredKey) return res.status(400).json({ error: 'Could not derive a valid instance id from the supplied name.' });
+    if (currentConfig.providers?.[desiredKey]) {
+      return res.status(409).json({ error: `Endpoint with id "${getOpenAICompatibleInstanceId(desiredKey)}" already exists.` });
+    }
+
+    upsertOpenAICompatibleEndpoint(currentConfig, {
+      instanceKey: desiredKey,
+      name: name || getOpenAICompatibleInstanceId(desiredKey),
+      baseUrl: baseUrl || '',
+      modelId: modelId || '',
+      apiKey: apiKey === undefined ? undefined : apiKey,
+      enabled: enabled !== false,
+    });
+    saveConfig(currentConfig);
+
+    void triggerImmediateProviderPing(desiredKey);
+
+    return res.json({ success: true, instanceKey: desiredKey, id: getOpenAICompatibleInstanceId(desiredKey) });
+  });
+
+  app.delete('/api/openai-compatible/endpoints/:id', (req, res) => {
+    const id = req.params.id;
+    const instanceKey = buildOpenAICompatibleInstanceKey(id);
+    if (!instanceKey) return res.status(400).json({ error: 'Invalid id.' });
+
+    const currentConfig = loadConfig();
+    const removed = removeOpenAICompatibleEndpoint(currentConfig, instanceKey);
+    if (!removed) return res.status(404).json({ error: 'Endpoint not found.' });
+    saveConfig(currentConfig);
+
+    // Drop result rows for the removed instance so it disappears from the dashboard.
+    void refreshOpenAICompatibleModels();
+
+    return res.json({ success: true });
   });
 
   app.post('/api/providers/:providerKey/refresh', async (req, res) => {
     const { providerKey } = req.params;
-    if (!sources[providerKey]) {
+    const baseKey = getBaseProviderKey(providerKey);
+    if (!sources[baseKey]) {
       return res.status(404).json({ error: 'Unknown provider.' });
     }
+    const providerName = sources[baseKey].name;
 
     try {
       const models = await refreshProviderModelsForApi(providerKey);
@@ -1508,7 +1587,7 @@ export async function runServer(config, port, enableLog = true, bannedModels = [
       return res.json({
         success: true,
         providerKey,
-        providerName: sources[providerKey].name,
+        providerName,
         models: models.map(model => ({
           modelId: model.modelId,
           label: model.label,
@@ -1521,7 +1600,7 @@ export async function runServer(config, port, enableLog = true, bannedModels = [
       return res.status(502).json({
         success: false,
         providerKey,
-        providerName: sources[providerKey].name,
+        providerName,
         error: describeSyncError(err),
       });
     }
@@ -1529,23 +1608,30 @@ export async function runServer(config, port, enableLog = true, bannedModels = [
 
   app.post('/api/providers/refresh-all', async (req, res) => {
     const currentConfig = loadConfig();
-    const providerKeys = Object.keys(sources).filter(key => isProviderEnabled(currentConfig, key));
+    const sourceKeys = Object.keys(sources)
+      .filter(key => key !== OPENAI_COMPATIBLE_PROVIDER_KEY)
+      .filter(key => isProviderEnabled(currentConfig, key));
+    const instanceKeys = listOpenAICompatibleEndpoints(currentConfig)
+      .filter(ep => ep.enabled)
+      .map(ep => ep.instanceKey);
+    const providerKeys = [...sourceKeys, ...instanceKeys];
     const results_arr = [];
 
     for (const providerKey of providerKeys) {
+      const providerName = sources[getBaseProviderKey(providerKey)]?.name || providerKey;
       try {
         const models = await refreshProviderModelsForApi(providerKey);
         results_arr.push({
           success: true,
           providerKey,
-          providerName: sources[providerKey].name,
+          providerName,
           modelCount: models.length,
         });
       } catch (err) {
         results_arr.push({
           success: false,
           providerKey,
-          providerName: sources[providerKey].name,
+          providerName,
           error: describeSyncError(err),
         });
       }
@@ -1796,7 +1882,7 @@ export async function runServer(config, port, enableLog = true, bannedModels = [
       void triggerImmediateProviderPing(providerKey);
     } else if (providerKey === OPENROUTER_PROVIDER_KEY && apiKey !== undefined) {
       void triggerImmediateProviderPing(providerKey);
-    } else if ((providerKey === OPENAI_COMPATIBLE_PROVIDER_KEY || providerKey === OLLAMA_PROVIDER_KEY) && (apiKey !== undefined || baseUrl !== undefined || modelId !== undefined)) {
+    } else if ((isOpenAICompatibleInstanceKey(providerKey) || providerKey === OPENAI_COMPATIBLE_PROVIDER_KEY || providerKey === OLLAMA_PROVIDER_KEY) && (apiKey !== undefined || baseUrl !== undefined || modelId !== undefined)) {
       void triggerImmediateProviderPing(providerKey);
     }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -159,10 +159,24 @@ export function isModelEligibleForRouting(r) {
   return r.status !== 'banned' && r.status !== 'disabled' && r.status !== 'excluded'
 }
 
+export function getRoutingModelKey(r) {
+  const provider = normalizeModelAlias(r?.providerKey)
+  const model = normalizeModelAlias(r?.modelId)
+  return provider ? `${provider}/${model}` : model
+}
+
+function normalizeExcludedModelKeys(excludedModelIds = []) {
+  return new Set(excludedModelIds.map(value => normalizeModelAlias(value)))
+}
+
+function isRoutingModelExcluded(r, excluded) {
+  return excluded.has(normalizeModelAlias(r?.modelId)) || excluded.has(getRoutingModelKey(r))
+}
+
 export function rankModelsForRouting(results, excludedModelIds = []) {
-  const excluded = new Set(excludedModelIds)
-  const eligible = results.filter(r => isModelEligibleForRouting(r) && !excluded.has(r.modelId))
-  const qosMap = computeQoSMap(results, excludedModelIds)
+  const excluded = normalizeExcludedModelKeys(excludedModelIds)
+  const eligible = results.filter(r => isModelEligibleForRouting(r) && !isRoutingModelExcluded(r, excluded))
+  const qosMap = computeQoSMap(eligible)
   const scored = eligible.map(r => ({ r, qos: qosMap.get(r) || 0 }))
   scored.sort((a, b) => b.qos - a.qos)
   return scored.map(s => s.r)
@@ -243,7 +257,24 @@ function toDisplayModelLabel(label, fallback) {
   return fallback
 }
 
-function getModelGroupKey(r, canonicalizeFn) {
+function getExactModelCounts(results) {
+  const counts = new Map()
+  for (const r of results) {
+    const key = normalizeModelAlias(r?.modelId)
+    if (!key) continue
+    counts.set(key, (counts.get(key) || 0) + 1)
+  }
+  return counts
+}
+
+function hasDuplicateExactModelId(r, exactModelCounts) {
+  const key = normalizeModelAlias(r?.modelId)
+  return key && normalizeModelAlias(r?.providerKey).startsWith('openai-compatible:') && (exactModelCounts.get(key) || 0) > 1
+}
+
+function getModelGroupKey(r, canonicalizeFn, exactModelCounts) {
+  if (hasDuplicateExactModelId(r, exactModelCounts)) return getRoutingModelKey(r)
+
   const labelKey = normalizeModelLabel(r?.label)
   if (labelKey) return labelKey
 
@@ -274,7 +305,9 @@ function collectModelAliases(r, canonicalizeFn) {
   return aliases
 }
 
-function getModelGroupId(r, canonicalizeFn, displayLabel) {
+function getModelGroupId(r, canonicalizeFn, displayLabel, exactModelCounts) {
+  if (hasDuplicateExactModelId(r, exactModelCounts)) return getRoutingModelKey(r)
+
   if (typeof canonicalizeFn === 'function') {
     const { unprefixed, base } = canonicalizeFn(r?.modelId || '')
     const canonicalId = normalizeModelAlias(unprefixed || base)
@@ -287,14 +320,15 @@ function getModelGroupId(r, canonicalizeFn, displayLabel) {
 
 export function buildModelGroups(results, canonicalizeFn) {
   const groups = new Map()
+  const exactModelCounts = getExactModelCounts(results)
 
   for (const r of results) {
-    const key = getModelGroupKey(r, canonicalizeFn)
+    const key = getModelGroupKey(r, canonicalizeFn, exactModelCounts)
     if (!key) continue
 
     if (!groups.has(key)) {
       const displayLabel = toDisplayModelLabel(r.label, r.modelId)
-      const groupId = getModelGroupId(r, canonicalizeFn, displayLabel)
+      const groupId = getModelGroupId(r, canonicalizeFn, displayLabel, exactModelCounts)
       groups.set(key, {
         id: groupId,
         label: displayLabel,
@@ -324,6 +358,9 @@ export function filterModelsByRequested(results, requestedModel, canonicalizeFn)
   if (!requestedModel || requestedModel === 'auto-fastest') return results
 
   const requested = normalizeModelAlias(requestedModel)
+  const providerQualifiedMatches = results.filter(r => getRoutingModelKey(r) === requested)
+  if (providerQualifiedMatches.length > 0) return providerQualifiedMatches
+
   const exactMatches = results.filter(r => normalizeModelAlias(r.modelId) === requested)
   if (exactMatches.length > 0) return exactMatches
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "modelrelay",
-  "version": "1.15.1",
+  "version": "1.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "modelrelay",
-      "version": "1.15.1",
+      "version": "1.16.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.4.1",

--- a/public/index.html
+++ b/public/index.html
@@ -3753,17 +3753,23 @@
           const showsBaseUrlFields = p.isOpenAICompatibleInstance || p.key === 'ollama';
           const baseUrlPlaceholder = p.key === 'ollama' ? 'https://ollama.com/v1' : 'https://your-endpoint.example/v1';
           const baseUrlNote = p.isOpenAICompatibleInstance
-            ? 'Set the upstream base URL and exact model ID for this endpoint.'
+            ? 'Set the upstream base URL for this endpoint. The model id below is optional — leave blank if discovery returns the models you need.'
             : 'Set the upstream base URL and exact model ID for this provider. If base URL is blank, modelrelay uses https://ollama.com/v1 and expects an OLLAMA_API_KEY.';
           const openAiCompatibleFieldsHtml = showsBaseUrlFields ? `
             <div class="form-group" style="display:flex; gap:8px; align-items:center; margin-top:8px;">
               <input type="text" id="base-url-${p.key}" value="${escapeHtml(p.baseUrl || '')}" placeholder="${baseUrlPlaceholder}" style="flex:1;" onblur="updateProviderBaseUrl('${p.key}')">
             </div>
             <div class="form-group" style="display:flex; gap:8px; align-items:center; margin-top:8px;">
-              <input type="text" id="model-id-${p.key}" value="${escapeHtml(p.modelId || '')}" placeholder="upstream-model-id" style="flex:1;" onblur="updateProviderModelId('${p.key}')">
+              <input type="text" id="model-id-${p.key}" value="${escapeHtml(p.modelId || '')}" placeholder="upstream-model-id (optional if discovery is on)" style="flex:1;" onblur="updateProviderModelId('${p.key}')">
             </div>
             <div style="font-size:0.75rem; color:var(--text-muted); margin-top:4px;">${baseUrlNote}</div>
             ${p.isOpenAICompatibleInstance ? `
+              <div style="margin-top:10px; display:flex; align-items:center; gap:8px; flex-wrap:wrap;">
+                <label style="display:flex; align-items:center; gap:6px; font-size:0.8rem; cursor:pointer;">
+                  <input type="checkbox" id="discover-${p.key}" ${p.discoverModels !== false ? 'checked' : ''} onchange="updateProviderDiscoverModels('${p.key}')">
+                  Discover models from <code>/v1/models</code>
+                </label>
+              </div>
               <div style="margin-top:10px; display:flex; justify-content:flex-end;">
                 <button onclick="removeOpenAICompatibleEndpoint('${escapeHtml(p.openAICompatibleInstanceId)}', ${JSON.stringify(p.name)})" style="border:1px solid var(--status-error-border); background:var(--status-error-bg); color:var(--status-error-text); cursor:pointer; padding:6px 12px; border-radius:6px; font-size:0.78rem; font-weight:600;">Remove Endpoint</button>
               </div>
@@ -3899,7 +3905,7 @@
       const name = prompt('Endpoint name (e.g. "my-vllm")');
       if (!name || !name.trim()) return;
       const baseUrl = prompt('Base URL (e.g. https://your-host/v1)') || '';
-      const modelId = prompt('Upstream model id (exact)') || '';
+      const modelId = prompt('Upstream model id (optional — leave blank to rely on /v1/models discovery)') || '';
       const apiKey = prompt('API key (leave blank if not required)') || '';
       const resp = await fetch('/api/openai-compatible/endpoints', {
         method: 'POST',
@@ -3913,6 +3919,17 @@
         return;
       }
       await loadSettings();
+      await fetchData();
+    }
+
+    async function updateProviderDiscoverModels(key) {
+      const cb = document.getElementById(`discover-${key}`);
+      const discoverModels = cb ? !!cb.checked : true;
+      await fetch('/api/config', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ providerKey: key, discoverModels })
+      });
       await fetchData();
     }
 

--- a/public/index.html
+++ b/public/index.html
@@ -3665,6 +3665,17 @@
         const container = document.getElementById('providers-container');
         container.innerHTML = '';
 
+        const addEndpointSection = document.createElement('div');
+        addEndpointSection.className = 'provider-section';
+        addEndpointSection.innerHTML = `
+          <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:0.5rem;">
+            <h3 style="margin:0; font-size:1rem;">OpenAI-Compatible endpoints</h3>
+            <button onclick="addOpenAICompatibleEndpoint()" style="border:1px solid var(--status-success-border); background:var(--status-success-bg); color:var(--status-success-text); cursor:pointer; padding:6px 12px; border-radius:6px; font-size:0.8rem; font-weight:600;">+ Add Endpoint</button>
+          </div>
+          <div style="font-size:0.78rem; color:var(--text-muted);">Configure one or more upstream OpenAI-compatible endpoints (vLLM, llama.cpp, custom relays, etc.). Each endpoint exposes a single model id.</div>
+        `;
+        container.appendChild(addEndpointSection);
+
         providers.sort((a, b) => {
           if (a.hasKey && !b.hasKey) return -1;
           if (!a.hasKey && b.hasKey) return 1;
@@ -3739,14 +3750,24 @@
               </div>`;
           }
 
-          const openAiCompatibleFieldsHtml = (p.key === 'openai-compatible' || p.key === 'ollama') ? `
+          const showsBaseUrlFields = p.isOpenAICompatibleInstance || p.key === 'ollama';
+          const baseUrlPlaceholder = p.key === 'ollama' ? 'https://ollama.com/v1' : 'https://your-endpoint.example/v1';
+          const baseUrlNote = p.isOpenAICompatibleInstance
+            ? 'Set the upstream base URL and exact model ID for this endpoint.'
+            : 'Set the upstream base URL and exact model ID for this provider. If base URL is blank, modelrelay uses https://ollama.com/v1 and expects an OLLAMA_API_KEY.';
+          const openAiCompatibleFieldsHtml = showsBaseUrlFields ? `
             <div class="form-group" style="display:flex; gap:8px; align-items:center; margin-top:8px;">
-              <input type="text" id="base-url-${p.key}" value="${escapeHtml(p.baseUrl || '')}" placeholder="${p.key === 'ollama' ? 'https://ollama.com/v1' : 'https://your-endpoint.example/v1'}" style="flex:1;" onblur="updateProviderBaseUrl('${p.key}')">
+              <input type="text" id="base-url-${p.key}" value="${escapeHtml(p.baseUrl || '')}" placeholder="${baseUrlPlaceholder}" style="flex:1;" onblur="updateProviderBaseUrl('${p.key}')">
             </div>
             <div class="form-group" style="display:flex; gap:8px; align-items:center; margin-top:8px;">
               <input type="text" id="model-id-${p.key}" value="${escapeHtml(p.modelId || '')}" placeholder="upstream-model-id" style="flex:1;" onblur="updateProviderModelId('${p.key}')">
             </div>
-            <div style="font-size:0.75rem; color:var(--text-muted); margin-top:4px;">Set the upstream base URL and exact model ID for this provider.${p.key === 'ollama' ? ' If base URL is blank, modelrelay uses https://ollama.com/v1 and expects an OLLAMA_API_KEY.' : ''}</div>
+            <div style="font-size:0.75rem; color:var(--text-muted); margin-top:4px;">${baseUrlNote}</div>
+            ${p.isOpenAICompatibleInstance ? `
+              <div style="margin-top:10px; display:flex; justify-content:flex-end;">
+                <button onclick="removeOpenAICompatibleEndpoint('${escapeHtml(p.openAICompatibleInstanceId)}', ${JSON.stringify(p.name)})" style="border:1px solid var(--status-error-border); background:var(--status-error-bg); color:var(--status-error-text); cursor:pointer; padding:6px 12px; border-radius:6px; font-size:0.78rem; font-weight:600;">Remove Endpoint</button>
+              </div>
+            ` : ''}
           ` : '';
 
           const optionalBearerAuthHtml = (tokenOptional && p.hasKey) ? `
@@ -3871,6 +3892,40 @@
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ providerKey: key, baseUrl })
       });
+      await fetchData();
+    }
+
+    async function addOpenAICompatibleEndpoint() {
+      const name = prompt('Endpoint name (e.g. "my-vllm")');
+      if (!name || !name.trim()) return;
+      const baseUrl = prompt('Base URL (e.g. https://your-host/v1)') || '';
+      const modelId = prompt('Upstream model id (exact)') || '';
+      const apiKey = prompt('API key (leave blank if not required)') || '';
+      const resp = await fetch('/api/openai-compatible/endpoints', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: name.trim(), baseUrl: baseUrl.trim(), modelId: modelId.trim(), apiKey: apiKey.trim() || null })
+      });
+      if (!resp.ok) {
+        let msg = `HTTP ${resp.status}`;
+        try { const body = await resp.json(); if (body && body.error) msg = body.error; } catch {}
+        alert(`Could not add endpoint: ${msg}`);
+        return;
+      }
+      await loadSettings();
+      await fetchData();
+    }
+
+    async function removeOpenAICompatibleEndpoint(id, name) {
+      if (!confirm(`Remove endpoint "${name}"?`)) return;
+      const resp = await fetch(`/api/openai-compatible/endpoints/${encodeURIComponent(id)}`, { method: 'DELETE' });
+      if (!resp.ok) {
+        let msg = `HTTP ${resp.status}`;
+        try { const body = await resp.json(); if (body && body.error) msg = body.error; } catch {}
+        alert(`Could not remove endpoint: ${msg}`);
+        return;
+      }
+      await loadSettings();
       await fetchData();
     }
 

--- a/test/test.js
+++ b/test/test.js
@@ -26,7 +26,7 @@ import { normalizeMissingScoreId } from '../lib/score-fetcher.js'
 import { resolveAutostartExecPath, resolveAutostartNodePath } from '../lib/autostart.js'
 import { exportConfigToken, getApiKey, getApiKeyPool, getMaxTurns, getPinningMode, getProviderBaseUrl, getProviderModelId, getProviderPingIntervalMs, hasMultipleKeys, importConfigToken, normalizeConfigShape, isOpenAICompatibleInstanceKey, getBaseProviderKey, getOpenAICompatibleInstanceId, buildOpenAICompatibleInstanceKey, listOpenAICompatibleEndpoints, upsertOpenAICompatibleEndpoint, removeOpenAICompatibleEndpoint } from '../lib/config.js'
 import { buildNpmInstallInvocation, buildWindowsPostUpdateRestartCommand, getForcedUpdateVersion, getLocalUpdateTarballPath, getLocalUpdateVersion, isRunningFromSource, shouldStopAutostartBeforeUpdate } from '../lib/update.js'
-import { buildOpencodeHeaders, buildOpencodeProjectId, buildProviderRequestHeaders, extractOllamaModelRecords, getAccountStatus, getPinnedModelCandidate, getPinnedModelMatches, isProviderAuthOptional, isProviderBearerAuthEnabled, providerWantsBearerAuth, shouldRetryOptionalProviderWithBearer, toOllamaModelMeta, toOpenCodeModelMeta, toOpenRouterModelMeta, toKiloCodeModelMeta } from '../lib/server.js'
+import { buildOpencodeHeaders, buildOpencodeProjectId, buildProviderRequestHeaders, extractOllamaModelRecords, extractOpenAICompatibleModelRecords, buildOpenAICompatibleModelsListUrl, getAccountStatus, getPinnedModelCandidate, getPinnedModelMatches, isProviderAuthOptional, isProviderBearerAuthEnabled, providerWantsBearerAuth, shouldRetryOptionalProviderWithBearer, toOllamaModelMeta, toOpenAICompatibleDiscoveredModelMeta, toOpenCodeModelMeta, toOpenRouterModelMeta, toKiloCodeModelMeta } from '../lib/server.js'
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const ROOT = join(__dirname, '..')
 
@@ -1662,6 +1662,18 @@ describe('OpenAI-compatible multi-instance support', () => {
     assert.equal(removeOpenAICompatibleEndpoint(config, 'groq'), false)
   })
 
+  it('upsertOpenAICompatibleEndpoint persists discoverModels=false explicitly', () => {
+    const config = { apiKeys: {}, providers: {} }
+    upsertOpenAICompatibleEndpoint(config, { id: 'one', name: 'One', baseUrl: 'http://h/v1' })
+    assert.equal(config.providers['openai-compatible:one'].discoverModels, undefined)
+
+    upsertOpenAICompatibleEndpoint(config, { instanceKey: 'openai-compatible:one', discoverModels: false })
+    assert.equal(config.providers['openai-compatible:one'].discoverModels, false)
+
+    upsertOpenAICompatibleEndpoint(config, { instanceKey: 'openai-compatible:one', discoverModels: true })
+    assert.equal('discoverModels' in config.providers['openai-compatible:one'], false)
+  })
+
   it('config export/import preserves multi-instance shape', () => {
     const original = normalizeConfigShape({
       apiKeys: {
@@ -1681,5 +1693,56 @@ describe('OpenAI-compatible multi-instance support', () => {
     assert.equal(reimported.apiKeys['openai-compatible:beta'], 'sk-b')
     assert.equal(reimported.providers['openai-compatible:alpha'].name, 'Alpha')
     assert.equal(reimported.providers['openai-compatible:beta'].modelId, 'b-model')
+  })
+})
+
+describe('OpenAI-compatible model discovery', () => {
+  it('builds the /v1/models URL from a variety of base URLs', () => {
+    assert.equal(buildOpenAICompatibleModelsListUrl('https://api.example.com'), 'https://api.example.com/v1/models')
+    assert.equal(buildOpenAICompatibleModelsListUrl('https://api.example.com/'), 'https://api.example.com/v1/models')
+    assert.equal(buildOpenAICompatibleModelsListUrl('https://api.example.com/v1'), 'https://api.example.com/v1/models')
+    assert.equal(buildOpenAICompatibleModelsListUrl('https://api.example.com/v1/'), 'https://api.example.com/v1/models')
+    assert.equal(buildOpenAICompatibleModelsListUrl('https://api.example.com/v1/chat/completions'), 'https://api.example.com/v1/models')
+    assert.equal(buildOpenAICompatibleModelsListUrl('https://api.example.com/v1/models'), 'https://api.example.com/v1/models')
+    assert.equal(buildOpenAICompatibleModelsListUrl('api.example.com/v1'), 'https://api.example.com/v1/models')
+    assert.equal(buildOpenAICompatibleModelsListUrl(''), null)
+    assert.equal(buildOpenAICompatibleModelsListUrl(null), null)
+  })
+
+  it('extracts records from common payload shapes', () => {
+    assert.deepEqual(extractOpenAICompatibleModelRecords({ data: [{ id: 'a' }, { id: 'b' }] }), [{ id: 'a' }, { id: 'b' }])
+    assert.deepEqual(extractOpenAICompatibleModelRecords({ models: [{ id: 'a' }] }), [{ id: 'a' }])
+    assert.deepEqual(extractOpenAICompatibleModelRecords([{ id: 'a' }]), [{ id: 'a' }])
+    assert.deepEqual(extractOpenAICompatibleModelRecords({}), [])
+    assert.deepEqual(extractOpenAICompatibleModelRecords(null), [])
+  })
+
+  it('converts a discovered record to a model-meta tagged with the instance key', () => {
+    const meta = toOpenAICompatibleDiscoveredModelMeta(
+      { id: 'qwen2.5-coder:7b', context_length: 32768, name: 'Qwen2.5 Coder 7B' },
+      'openai-compatible:my-vllm',
+      'https://host/v1/chat/completions',
+    )
+    assert.ok(meta)
+    assert.equal(meta.modelId, 'qwen2.5-coder:7b')
+    assert.equal(meta.label, 'Qwen2.5 Coder 7B')
+    assert.equal(meta.providerKey, 'openai-compatible:my-vllm')
+    assert.equal(meta.providerUrl, 'https://host/v1/chat/completions')
+    // 32768 → "33k" via the shared parser
+    assert.equal(meta.ctx, '33k')
+  })
+
+  it('falls back to a synthesized label when the record has none', () => {
+    const meta = toOpenAICompatibleDiscoveredModelMeta({ id: 'some_unknown-model' }, 'openai-compatible:x')
+    assert.ok(meta)
+    assert.equal(meta.modelId, 'some_unknown-model')
+    assert.equal(meta.label, 'Some Unknown Model')
+    assert.equal(meta.isEstimatedScore, true)
+  })
+
+  it('rejects records without a usable id', () => {
+    assert.equal(toOpenAICompatibleDiscoveredModelMeta({}, 'openai-compatible:x'), null)
+    assert.equal(toOpenAICompatibleDiscoveredModelMeta({ id: '   ' }, 'openai-compatible:x'), null)
+    assert.equal(toOpenAICompatibleDiscoveredModelMeta('', 'openai-compatible:x'), null)
   })
 })

--- a/test/test.js
+++ b/test/test.js
@@ -13,6 +13,7 @@ import {
   sortResults,
   findBestModel,
   rankModelsForRouting,
+  getRoutingModelKey,
   buildModelGroups,
   filterModelsByRequested,
   isRetryableProxyStatus,
@@ -1203,6 +1204,18 @@ describe('model grouping and filtering', () => {
     assert.equal(groups[0].id, 'minimax-m2.5')
   })
 
+  it('keeps duplicate raw model ids from different providers addressable', () => {
+    const groups = buildModelGroups([
+      mockResult({ modelId: 'llama-3.1', label: 'Llama 3.1', providerKey: 'openai-compatible:local' }),
+      mockResult({ modelId: 'llama-3.1', label: 'Llama 3.1', providerKey: 'openai-compatible:remote' }),
+    ], canonicalizeModelId)
+
+    assert.deepEqual(groups.map(group => group.id).sort(), [
+      'openai-compatible:local/llama-3.1',
+      'openai-compatible:remote/llama-3.1',
+    ])
+  })
+
   it('groups MiMo Omni aliases under one model name', () => {
     const groups = buildModelGroups([
       mockResult({ modelId: 'mimo-v2-omni-free', label: 'MiMo V2 Omni' }),
@@ -1269,6 +1282,17 @@ describe('model grouping and filtering', () => {
     const filtered = filterModelsByRequested(results, 'auto-fastest', canonicalizeModelId)
     assert.equal(filtered.length, 3)
   })
+
+  it('filters duplicate raw model ids by endpoint-qualified group id', () => {
+    const duplicateResults = [
+      mockResult({ modelId: 'llama-3.1', label: 'Llama 3.1', providerKey: 'openai-compatible:local' }),
+      mockResult({ modelId: 'llama-3.1', label: 'Llama 3.1', providerKey: 'openai-compatible:remote' }),
+    ]
+
+    const filtered = filterModelsByRequested(duplicateResults, 'openai-compatible:remote/llama-3.1', canonicalizeModelId)
+
+    assert.deepEqual(filtered.map(r => r.providerKey), ['openai-compatible:remote'])
+  })
 })
 
 describe('pinned model routing', () => {
@@ -1297,6 +1321,18 @@ describe('pinned model routing', () => {
   it('routes to the best eligible provider within a canonical pin group', () => {
     const candidate = getPinnedModelCandidate(results, 'nvidia/glm4.7', 'canonical')
     assert.equal(candidate?.modelId, 'nvidia/glm4.7')
+  })
+
+  it('can retry another provider with the same raw model id', () => {
+    const duplicateResults = [
+      mockResult({ modelId: 'llama-3.1', label: 'Llama 3.1', providerKey: 'openai-compatible:local', pings: [{ ms: 90, code: '200' }], intell: 10 }),
+      mockResult({ modelId: 'llama-3.1', label: 'Llama 3.1', providerKey: 'openai-compatible:remote', pings: [{ ms: 100, code: '200' }], intell: 10 }),
+    ]
+    const first = rankModelsForRouting(duplicateResults)[0]
+    const second = rankModelsForRouting(duplicateResults, [getRoutingModelKey(first)])[0]
+
+    assert.equal(first.providerKey, 'openai-compatible:local')
+    assert.equal(second.providerKey, 'openai-compatible:remote')
   })
 })
 

--- a/test/test.js
+++ b/test/test.js
@@ -24,7 +24,7 @@ import {
 import { buildOpenClawProviderConfig } from '../lib/onboard.js'
 import { normalizeMissingScoreId } from '../lib/score-fetcher.js'
 import { resolveAutostartExecPath, resolveAutostartNodePath } from '../lib/autostart.js'
-import { exportConfigToken, getApiKey, getApiKeyPool, getMaxTurns, getPinningMode, getProviderBaseUrl, getProviderModelId, getProviderPingIntervalMs, hasMultipleKeys, importConfigToken, normalizeConfigShape } from '../lib/config.js'
+import { exportConfigToken, getApiKey, getApiKeyPool, getMaxTurns, getPinningMode, getProviderBaseUrl, getProviderModelId, getProviderPingIntervalMs, hasMultipleKeys, importConfigToken, normalizeConfigShape, isOpenAICompatibleInstanceKey, getBaseProviderKey, getOpenAICompatibleInstanceId, buildOpenAICompatibleInstanceKey, listOpenAICompatibleEndpoints, upsertOpenAICompatibleEndpoint, removeOpenAICompatibleEndpoint } from '../lib/config.js'
 import { buildNpmInstallInvocation, buildWindowsPostUpdateRestartCommand, getForcedUpdateVersion, getLocalUpdateTarballPath, getLocalUpdateVersion, isRunningFromSource, shouldStopAutostartBeforeUpdate } from '../lib/update.js'
 import { buildOpencodeHeaders, buildOpencodeProjectId, buildProviderRequestHeaders, extractOllamaModelRecords, getAccountStatus, getPinnedModelCandidate, getPinnedModelMatches, isProviderAuthOptional, isProviderBearerAuthEnabled, providerWantsBearerAuth, shouldRetryOptionalProviderWithBearer, toOllamaModelMeta, toOpenCodeModelMeta, toOpenRouterModelMeta, toKiloCodeModelMeta } from '../lib/server.js'
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -1512,5 +1512,174 @@ describe('multi-account round-robin', () => {
       assert.equal(entry.accounts.get(0).requests, 1)
       assert.equal(entry.accounts.get(1).requests, 0)
     })
+  })
+})
+
+describe('OpenAI-compatible multi-instance support', () => {
+  it('detects instance keys and extracts ids', () => {
+    assert.equal(isOpenAICompatibleInstanceKey('openai-compatible:default'), true)
+    assert.equal(isOpenAICompatibleInstanceKey('openai-compatible:my-vllm'), true)
+    assert.equal(isOpenAICompatibleInstanceKey('openai-compatible'), false)
+    assert.equal(isOpenAICompatibleInstanceKey('groq'), false)
+
+    assert.equal(getOpenAICompatibleInstanceId('openai-compatible:my-vllm'), 'my-vllm')
+    assert.equal(getOpenAICompatibleInstanceId('groq'), null)
+
+    assert.equal(getBaseProviderKey('openai-compatible:my-vllm'), 'openai-compatible')
+    assert.equal(getBaseProviderKey('groq'), 'groq')
+  })
+
+  it('builds instance keys from human-friendly names', () => {
+    assert.equal(buildOpenAICompatibleInstanceKey('My vLLM '), 'openai-compatible:my-vllm')
+    assert.equal(buildOpenAICompatibleInstanceKey('Foo Bar 123'), 'openai-compatible:foo-bar-123')
+    assert.equal(buildOpenAICompatibleInstanceKey(''), null)
+    assert.equal(buildOpenAICompatibleInstanceKey('!!!'), null)
+  })
+
+  it('normalizeConfigShape migrates a legacy bare-key config to :default', () => {
+    const legacy = {
+      apiKeys: { 'openai-compatible': 'sk-legacy' },
+      providers: { 'openai-compatible': { enabled: true, baseUrl: 'https://legacy.example/v1', modelId: 'old/model' } },
+    }
+    const normalized = normalizeConfigShape(legacy)
+    assert.equal(normalized.apiKeys['openai-compatible'], undefined)
+    assert.equal(normalized.providers['openai-compatible'], undefined)
+    assert.equal(normalized.apiKeys['openai-compatible:default'], 'sk-legacy')
+    assert.deepEqual(normalized.providers['openai-compatible:default'], {
+      enabled: true,
+      baseUrl: 'https://legacy.example/v1',
+      modelId: 'old/model',
+      name: 'Default',
+    })
+  })
+
+  it('normalizeConfigShape leaves a config without legacy entries alone', () => {
+    const cfg = {
+      apiKeys: { 'openai-compatible:my-vllm': 'sk-vllm' },
+      providers: { 'openai-compatible:my-vllm': { name: 'vLLM', baseUrl: 'http://localhost:8000/v1', modelId: 'qwen' } },
+    }
+    const normalized = normalizeConfigShape(cfg)
+    assert.equal(normalized.apiKeys['openai-compatible:my-vllm'], 'sk-vllm')
+    assert.equal(normalized.providers['openai-compatible:my-vllm'].baseUrl, 'http://localhost:8000/v1')
+    // The bare entry should not be (re)created.
+    assert.equal(normalized.apiKeys['openai-compatible'], undefined)
+    assert.equal(normalized.providers['openai-compatible'], undefined)
+  })
+
+  it('normalizeConfigShape does not clobber an existing :default instance', () => {
+    const legacy = {
+      apiKeys: {
+        'openai-compatible': 'sk-legacy',
+        'openai-compatible:default': 'sk-already-here',
+      },
+      providers: {
+        'openai-compatible': { baseUrl: 'https://legacy.example/v1' },
+        'openai-compatible:default': { name: 'Pre-existing', baseUrl: 'https://default.example/v1', modelId: 'm' },
+      },
+    }
+    const normalized = normalizeConfigShape(legacy)
+    assert.equal(normalized.apiKeys['openai-compatible:default'], 'sk-already-here')
+    assert.equal(normalized.providers['openai-compatible:default'].name, 'Pre-existing')
+    assert.equal(normalized.apiKeys['openai-compatible'], undefined)
+    assert.equal(normalized.providers['openai-compatible'], undefined)
+  })
+
+  it('legacy OPENAI_COMPATIBLE_* env vars feed the :default instance', () => {
+    const originalKey = process.env.OPENAI_COMPATIBLE_API_KEY
+    const originalBaseUrl = process.env.OPENAI_COMPATIBLE_BASE_URL
+    const originalModel = process.env.OPENAI_COMPATIBLE_MODEL
+
+    try {
+      process.env.OPENAI_COMPATIBLE_API_KEY = 'env-key'
+      process.env.OPENAI_COMPATIBLE_BASE_URL = 'https://env.example/v1'
+      process.env.OPENAI_COMPATIBLE_MODEL = 'env/model'
+
+      const config = { apiKeys: {}, providers: {} }
+      assert.equal(getApiKey(config, 'openai-compatible:default'), 'env-key')
+      assert.equal(getProviderBaseUrl(config, 'openai-compatible:default'), 'https://env.example/v1')
+      assert.equal(getProviderModelId(config, 'openai-compatible:default'), 'env/model')
+
+      // Env vars should NOT apply to a non-default instance.
+      assert.equal(getApiKey(config, 'openai-compatible:other'), null)
+      assert.equal(getProviderBaseUrl(config, 'openai-compatible:other'), null)
+    } finally {
+      if (originalKey == null) delete process.env.OPENAI_COMPATIBLE_API_KEY
+      else process.env.OPENAI_COMPATIBLE_API_KEY = originalKey
+      if (originalBaseUrl == null) delete process.env.OPENAI_COMPATIBLE_BASE_URL
+      else process.env.OPENAI_COMPATIBLE_BASE_URL = originalBaseUrl
+      if (originalModel == null) delete process.env.OPENAI_COMPATIBLE_MODEL
+      else process.env.OPENAI_COMPATIBLE_MODEL = originalModel
+    }
+  })
+
+  it('listOpenAICompatibleEndpoints returns instances in stable insertion order', () => {
+    const config = normalizeConfigShape({
+      apiKeys: {
+        'openai-compatible:alpha': 'sk-a',
+        'openai-compatible:beta': 'sk-b',
+      },
+      providers: {
+        'openai-compatible:alpha': { name: 'Alpha', baseUrl: 'https://a/v1', modelId: 'a-model' },
+        'openai-compatible:beta':  { name: 'Beta',  baseUrl: 'https://b/v1', modelId: 'b-model', enabled: false },
+      },
+    })
+
+    const list = listOpenAICompatibleEndpoints(config)
+    assert.equal(list.length, 2)
+    assert.equal(list[0].instanceKey, 'openai-compatible:alpha')
+    assert.equal(list[0].id, 'alpha')
+    assert.equal(list[0].name, 'Alpha')
+    assert.equal(list[0].baseUrl, 'https://a/v1')
+    assert.equal(list[0].modelId, 'a-model')
+    assert.equal(list[0].apiKey, 'sk-a')
+    assert.equal(list[0].enabled, true)
+
+    assert.equal(list[1].instanceKey, 'openai-compatible:beta')
+    assert.equal(list[1].enabled, false)
+  })
+
+  it('upsertOpenAICompatibleEndpoint and remove round-trip cleanly', () => {
+    const config = { apiKeys: {}, providers: {} }
+    const key1 = upsertOpenAICompatibleEndpoint(config, { id: 'one', name: 'One', baseUrl: 'https://one/v1', modelId: 'm1', apiKey: 'sk-1' })
+    assert.equal(key1, 'openai-compatible:one')
+    assert.equal(config.apiKeys[key1], 'sk-1')
+    assert.equal(config.providers[key1].baseUrl, 'https://one/v1')
+    assert.equal(config.providers[key1].name, 'One')
+
+    // Update preserves untouched fields.
+    upsertOpenAICompatibleEndpoint(config, { instanceKey: key1, modelId: 'm1-new' })
+    assert.equal(config.providers[key1].baseUrl, 'https://one/v1')
+    assert.equal(config.providers[key1].modelId, 'm1-new')
+
+    const removed = removeOpenAICompatibleEndpoint(config, key1)
+    assert.equal(removed, true)
+    assert.equal(config.apiKeys[key1], undefined)
+    assert.equal(config.providers[key1], undefined)
+
+    // Removing again is a no-op.
+    assert.equal(removeOpenAICompatibleEndpoint(config, key1), false)
+    // Refusing to remove a non-instance key.
+    assert.equal(removeOpenAICompatibleEndpoint(config, 'groq'), false)
+  })
+
+  it('config export/import preserves multi-instance shape', () => {
+    const original = normalizeConfigShape({
+      apiKeys: {
+        'openai-compatible:alpha': 'sk-a',
+        'openai-compatible:beta': 'sk-b',
+      },
+      providers: {
+        'openai-compatible:alpha': { name: 'Alpha', baseUrl: 'https://a/v1', modelId: 'a-model' },
+        'openai-compatible:beta':  { name: 'Beta',  baseUrl: 'https://b/v1', modelId: 'b-model' },
+      },
+    })
+
+    const token = exportConfigToken(original)
+    const reimported = importConfigToken(token)
+
+    assert.equal(reimported.apiKeys['openai-compatible:alpha'], 'sk-a')
+    assert.equal(reimported.apiKeys['openai-compatible:beta'], 'sk-b')
+    assert.equal(reimported.providers['openai-compatible:alpha'].name, 'Alpha')
+    assert.equal(reimported.providers['openai-compatible:beta'].modelId, 'b-model')
   })
 })


### PR DESCRIPTION
Closes #36

## Summary

Today modelrelay can talk to exactly one OpenAI-compatible upstream — the lone `openai-compatible` provider entry, parameterised by a single `baseUrl` / `modelId` / `apiKey`. This PR lets you configure many of them at once (vLLM, llama.cpp, custom relays, friend's modelrelay, etc.) and routes each as its own provider.

## Approach

Each endpoint becomes a synthetic provider key of the form `openai-compatible:<id>` (e.g. `openai-compatible:default`, `openai-compatible:my-vllm`). Because the dispatch / ping / round-robin / rate-limit pipeline already keys on `providerKey` strings, the only "new" code path is a small `getBaseProviderKey()` shim used in the handful of places that look something up against `sources` / `API_KEY_SIGNUP_URLS` / `OPTIONAL_BEARER_AUTH_PROVIDERS`. Everything else — multi-account API-key rotation, per-provider ping intervals, retries, exclusions — works automatically per instance.

### Config shape

```jsonc
{
  "apiKeys": {
    "openai-compatible:my-vllm":    "sk-…",
    "openai-compatible:groq-clone": "sk-…"
  },
  "providers": {
    "openai-compatible:my-vllm":    { "enabled": true, "name": "Local vLLM", "baseUrl": "http://localhost:8000/v1", "modelId": "qwen-coder" },
    "openai-compatible:groq-clone": { "enabled": true, "name": "Groq Clone", "baseUrl": "https://example/v1",        "modelId": "llama-3.3-70b" }
  }
}
```

### Backward compatibility

- A legacy bare `openai-compatible` entry (with `baseUrl` / `modelId`) is migrated in `normalizeConfigShape` to `openai-compatible:default` on first read and persisted on next save. Existing single-endpoint users see no change.
- The legacy `OPENAI_COMPATIBLE_API_KEY` / `OPENAI_COMPATIBLE_BASE_URL` / `OPENAI_COMPATIBLE_MODEL` env vars continue to work and are aliased to the `:default` instance.
- When env vars are set but no JSON entry exists yet, `listOpenAICompatibleEndpoints` synthesises a virtual `:default` row so the UI still surfaces the provider — matching pre-PR behaviour for headless / CI users.

## What changed

- **`lib/config.js`** — instance-key helpers (`isOpenAICompatibleInstanceKey`, `getBaseProviderKey`, `getOpenAICompatibleInstanceId`, `buildOpenAICompatibleInstanceKey`), CRUD helpers (`listOpenAICompatibleEndpoints`, `upsertOpenAICompatibleEndpoint`, `removeOpenAICompatibleEndpoint`), env-var aliasing, and the legacy → `:default` migration.
- **`lib/server.js`** — `refreshOpenAICompatibleModels` now iterates endpoints; `resolveProviderUrl` and the `/api/config` POST refresh trigger recognise instance keys; `getBaseProviderKey()` is used in the few places that look up `sources[…]`. New routes `POST /api/openai-compatible/endpoints` (body `{name, baseUrl, modelId, apiKey?}`, slugifies the name into the id, 409s on collision) and `DELETE /api/openai-compatible/endpoints/:id`. `GET /api/config` emits one row per instance and skips the bare template entry.
- **`public/index.html`** — the existing per-provider section happily renders one block per instance once the API emits them. Added a single "OpenAI-Compatible endpoints" group header with a `+ Add Endpoint` button and a `Remove Endpoint` button on each instance section.
- **`test/test.js`** — 9 new tests under "OpenAI-compatible multi-instance support": instance-key parsing, slug generation, legacy migration (incl. not clobbering an explicit `:default`), env-var aliasing, `listOpenAICompatibleEndpoints` ordering, upsert/remove round-trip, export/import preserving the shape.
- **`README.md`** — short subsection in `## Config` showing the JSON shape, the migration behaviour, and the new API routes.

## Test plan

- [x] `node --test test/test.js` — 148 tests pass (139 existing + 9 new).
- [x] Boot with empty config, `POST` two endpoints, both appear as separate rows in `GET /api/config` and `GET /api/models`; pings hit the configured hostnames; `POST /v1/chat/completions` with one of the model ids routes to the correct upstream (verified via the `[Router] ➡️ Proxying request … to openai-compatible:my-vllm/qwen-coder` log line).
- [x] `POST /api/openai-compatible/endpoints` with a duplicate id → `409`.
- [x] `POST /api/config` with `providerKey: openai-compatible:my-vllm` updates that specific instance's `baseUrl`.
- [x] `DELETE /api/openai-compatible/endpoints/:id` removes the entry from disk and drops its result rows on next refresh.
- [x] Boot with a legacy single-endpoint `~/.modelrelay.json` — config is rewritten with the entry under `openai-compatible:default`.
- [x] Boot with `OPENAI_COMPATIBLE_API_KEY` / `_BASE_URL` / `_MODEL` set and an empty config — a virtual `:default` instance appears in the UI and is routable.

## Out of scope

- Discovering a list of models from a single endpoint via its `/v1/models`. For now each instance still exposes one model id; configure two instances with the same `baseUrl` to expose two models. Happy to follow up if there's interest.