### PR TITLE
Add image input (vision) support to chat completions routing

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -8,6 +8,7 @@ import { MODELS, sources, canonicalizeModelId, getPreferredModelContext, getPref
 import { API_KEY_SIGNUP_URLS } from './providerLinks.js';
 import { getApiKey, getApiKeyPool, getMaxTurns, getPinningMode, getProviderBaseUrl, getProviderModelId, hasMultipleKeys, isProviderEnabled, getProviderPingIntervalMs, isAutoPingEnabled, loadConfig, saveConfig, exportConfigToken, importConfigToken } from './config.js';
 import { buildModelGroups, computeQoSMap, findBestModel, getAvg, getUptime, getVerdict, isRetryableProxyStatus, rankModelsForRouting, parseOpenRouterKeyRateLimit, filterModelsByRequested, selectNextApiKeyFromPool } from './utils.js';
+import { extractOllamaVisionFlag, extractOpenRouterVisionFlag, isVisionModelByName, messagesContainImageContent, redactImageContentInMessages } from './vision.js';
 import { getPreferredLanIpv4Address } from './network.js';
 import { createHash, randomUUID } from 'crypto';
 import { getAutostartStatus } from './autostart.js';
@@ -526,6 +527,7 @@ export function toOllamaModelMeta(record) {
     isEstimatedScore: !hasScore,
     ctx: getPreferredModelContext(scoreLookupId, known?.ctx || DEFAULT_DYNAMIC_MODEL_CTX),
     providerKey: OLLAMA_PROVIDER_KEY,
+    vision: extractOllamaVisionFlag(record),
   };
 }
 
@@ -685,7 +687,7 @@ export function toOpenRouterModelMeta(record) {
   return { modelId, label, intell, isEstimatedScore, ctx, providerKey: OPENROUTER_PROVIDER_KEY };
 }
 
-export async function fetchOpenRouterFreeModels(config) {
+export async function fetchOpenRouterModelCatalog(config) {
   const headers = { Accept: 'application/json' };
   const token = getApiKey(config, OPENROUTER_PROVIDER_KEY);
   if (token) {
@@ -707,19 +709,40 @@ export async function fetchOpenRouterFreeModels(config) {
     const payload = await response.json();
     const records = extractOpenRouterModelRecords(payload);
     const seen = new Set();
-    const models = [];
+    const freeModels = [];
+    const visionMap = new Map();
 
     for (const record of records) {
+      const rawId = String(record?.id || record?.model || record?.name || '').trim();
+      if (rawId) {
+        const flag = extractOpenRouterVisionFlag(record);
+        if (typeof flag === 'boolean') {
+          const { base, unprefixed } = canonicalizeModelId(rawId);
+          if (base) visionMap.set(base, flag);
+          if (unprefixed && unprefixed !== base) {
+            // Don't downgrade a true to a false from an aliased form.
+            if (!(visionMap.get(unprefixed) === true && flag === false)) {
+              visionMap.set(unprefixed, flag);
+            }
+          }
+        }
+      }
+
       const model = toOpenRouterModelMeta(record);
       if (!model || seen.has(model.modelId)) continue;
       seen.add(model.modelId);
-      models.push(model);
+      freeModels.push(model);
     }
 
-    return models;
+    return { freeModels, visionMap };
   } finally {
     clearTimeout(timeoutId);
   }
+}
+
+export async function fetchOpenRouterFreeModels(config) {
+  const { freeModels } = await fetchOpenRouterModelCatalog(config);
+  return freeModels;
 }
 
 export function buildOpencodeProjectId(seed = process.cwd()) {
@@ -940,6 +963,7 @@ export async function runServer(config, port, enableLog = true, bannedModels = [
       isEstimatedScore: isEstimatedScoreOverride ?? !hasScore,
       ctx,
       providerKey,
+      vision: null,
       status: 'pending',
       pings: [],
       httpCode: null,
@@ -949,7 +973,31 @@ export async function runServer(config, port, enableLog = true, bannedModels = [
     };
   };
 
+  // Cross-provider vision capability index, populated from OpenRouter's catalog
+  // (which exposes architecture.input_modalities). Looked up by canonical model id.
+  let openRouterVisionMap = new Map();
+  // Per-modelId overrides resolved from the model's own provider record (e.g. Ollama capabilities).
+  const providerVisionOverrides = new Map();
+
+  const resolveVisionFlag = (r) => {
+    if (!r || !r.modelId) return null;
+    const override = providerVisionOverrides.get(`${r.providerKey} ${r.modelId}`);
+    if (typeof override === 'boolean') return override;
+    const { base, unprefixed } = canonicalizeModelId(r.modelId);
+    const fromMap = openRouterVisionMap.get(base) ?? openRouterVisionMap.get(unprefixed);
+    if (typeof fromMap === 'boolean') return fromMap;
+    if (isVisionModelByName(r.modelId) || isVisionModelByName(base) || isVisionModelByName(unprefixed)) return true;
+    return null;
+  };
+
+  const applyVisionFlags = () => {
+    for (const r of results) {
+      r.vision = resolveVisionFlag(r);
+    }
+  };
+
   let results = MODELS.map((row, i) => toResultRow(row, i));
+  applyVisionFlags();
   let lastKiloCodeModelRefreshAt = 0;
   let lastOpenCodeModelRefreshAt = 0;
   let lastOllamaModelRefreshAt = 0;
@@ -970,7 +1018,16 @@ export async function runServer(config, port, enableLog = true, bannedModels = [
 
     results = results.filter(r => r.providerKey !== providerKey);
 
+    // Drop stale per-record vision overrides for this provider; rebuild below.
+    for (const key of Array.from(providerVisionOverrides.keys())) {
+      if (key.startsWith(`${providerKey} `)) providerVisionOverrides.delete(key);
+    }
+
     for (const model of models) {
+      if (typeof model.vision === 'boolean') {
+        providerVisionOverrides.set(`${providerKey} ${model.modelId}`, model.vision);
+      }
+
       const existing = byModelId.get(model.modelId);
       if (existing) {
         existing.label = getPreferredModelLabel(model.modelId, model.label);
@@ -990,6 +1047,7 @@ export async function runServer(config, port, enableLog = true, bannedModels = [
     }
 
     reindexResults();
+    applyVisionFlags();
   };
 
   const refreshKiloCodeModels = async (force = false) => {
@@ -1038,12 +1096,24 @@ export async function runServer(config, port, enableLog = true, bannedModels = [
     try {
       const currentConfig = loadConfig();
       if (!isProviderEnabled(currentConfig, OPENROUTER_PROVIDER_KEY)) {
+        // OpenRouter's catalog is the cross-provider truth source for vision capability;
+        // fetch it even when OpenRouter routing is disabled, so other providers benefit.
+        try {
+          const { visionMap } = await fetchOpenRouterModelCatalog(currentConfig);
+          if (visionMap.size > 0) {
+            openRouterVisionMap = visionMap;
+            applyVisionFlags();
+          }
+        } catch {}
         mergeDynamicProviderModels(OPENROUTER_PROVIDER_KEY, []);
         return [];
       }
-      const models = await fetchOpenRouterFreeModels(currentConfig);
-      mergeDynamicProviderModels(OPENROUTER_PROVIDER_KEY, models);
-      return models;
+      const { freeModels, visionMap } = await fetchOpenRouterModelCatalog(currentConfig);
+      if (visionMap.size > 0) {
+        openRouterVisionMap = visionMap;
+      }
+      mergeDynamicProviderModels(OPENROUTER_PROVIDER_KEY, freeModels);
+      return freeModels;
     } catch (err) {
       console.log(chalk.dim(`  [OpenRouter] Model sync skipped: ${describeSyncError(err)}`));
       throw err;
@@ -2047,17 +2117,33 @@ export async function runServer(config, port, enableLog = true, bannedModels = [
       const payload = req.body;
       const attemptedModelIds = new Set();
       const attempts = [];
-      const requestedModels = filterModelsByRequested(results, payload.model, canonicalizeModelId);
+      const hasImages = messagesContainImageContent(payload.messages);
+      let requestedModels = filterModelsByRequested(results, payload.model, canonicalizeModelId);
 
       if (payload.model && payload.model !== 'auto-fastest' && requestedModels.length === 0) {
         return res.status(404).json({ error: { message: `Requested model not found: ${payload.model}` } });
+      }
+
+      if (hasImages) {
+        const visionEligible = requestedModels.filter(r => r.vision === true);
+        if (payload.model && payload.model !== 'auto-fastest' && visionEligible.length === 0) {
+          return res.status(400).json({ error: {
+            message: `Model "${payload.model}" does not support image input. Use "auto-fastest" or pin a vision-capable model.`,
+          } });
+        }
+        if (visionEligible.length === 0) {
+          return res.status(503).json({ error: {
+            message: 'No vision-capable models currently available for this image request.',
+          } });
+        }
+        requestedModels = visionEligible;
       }
 
       const pickNextModel = () => {
         if (pinnedModelId) {
           const pinningMode = getPinningMode(loadConfig());
           const pinned = getPinnedModelCandidate(results, pinnedModelId, pinningMode, Array.from(attemptedModelIds), pinnedProviderKey);
-          if (pinned) {
+          if (pinned && (!hasImages || pinned.vision === true)) {
             return pinned;
           }
         }
@@ -2066,11 +2152,15 @@ export async function runServer(config, port, enableLog = true, bannedModels = [
         return ranked[0] || null;
       };
 
+      const loggedMessages = hasImages
+        ? redactImageContentInMessages(payload.messages || [])
+        : (payload.messages || []);
+
       logEntry = {
         timestamp: new Date().toISOString(),
         model: '(pending)',
         provider: '(pending)',
-        messages: payload.messages || [],
+        messages: loggedMessages,
         duration: null,
         ttft: null,
         status: 'pending',

--- a/lib/vision.js
+++ b/lib/vision.js
@@ -1,0 +1,71 @@
+/**
+ * @file lib/vision.js
+ * @description Pure helpers for detecting image (vision) capability on models
+ * and image content on chat completion requests.
+ */
+
+export const VISION_NAME_HEURISTIC = /(^|[-/_:])(vl|vision|omni|multimodal|mm)(?=[-:_/]|$)/i
+
+export function isVisionModelByName(modelId) {
+  if (typeof modelId !== 'string' || !modelId) return false
+  return VISION_NAME_HEURISTIC.test(modelId)
+}
+
+export function extractOpenRouterVisionFlag(record) {
+  if (!record || typeof record !== 'object') return null
+  const arch = record.architecture || record.arch || null
+  if (arch && Array.isArray(arch.input_modalities)) {
+    return arch.input_modalities.some(m => typeof m === 'string' && m.toLowerCase() === 'image')
+  }
+  if (arch && typeof arch.modality === 'string') {
+    return /image/i.test(arch.modality)
+  }
+  if (typeof record.modality === 'string') {
+    return /image/i.test(record.modality)
+  }
+  return null
+}
+
+export function extractOllamaVisionFlag(record) {
+  if (!record || typeof record !== 'object') return null
+  if (Array.isArray(record.capabilities)) {
+    return record.capabilities.some(c => typeof c === 'string' && c.toLowerCase() === 'vision')
+  }
+  return null
+}
+
+function partLooksLikeImage(part) {
+  if (!part || typeof part !== 'object') return false
+  const t = typeof part.type === 'string' ? part.type.toLowerCase() : ''
+  if (t === 'image_url' || t === 'image' || t === 'input_image') return true
+  if (part.image_url) return true
+  if (part.image && typeof part.image === 'object') return true
+  return false
+}
+
+export function messagesContainImageContent(messages) {
+  if (!Array.isArray(messages)) return false
+  for (const msg of messages) {
+    if (!msg || !Array.isArray(msg.content)) continue
+    for (const part of msg.content) {
+      if (partLooksLikeImage(part)) return true
+    }
+  }
+  return false
+}
+
+export function redactImageContentInMessages(messages) {
+  if (!Array.isArray(messages)) return messages
+  return messages.map(msg => {
+    if (!msg || !Array.isArray(msg.content)) return msg
+    if (!msg.content.some(partLooksLikeImage)) return msg
+    return {
+      ...msg,
+      content: msg.content.map(part =>
+        partLooksLikeImage(part)
+          ? { type: 'image_url', image_url: { url: '[image redacted]' } }
+          : part
+      ),
+    }
+  })
+}

--- a/test/test.js
+++ b/test/test.js
@@ -27,6 +27,7 @@ import { resolveAutostartExecPath, resolveAutostartNodePath } from '../lib/autos
 import { exportConfigToken, getApiKey, getApiKeyPool, getMaxTurns, getPinningMode, getProviderBaseUrl, getProviderModelId, getProviderPingIntervalMs, hasMultipleKeys, importConfigToken, normalizeConfigShape } from '../lib/config.js'
 import { buildNpmInstallInvocation, buildWindowsPostUpdateRestartCommand, getForcedUpdateVersion, getLocalUpdateTarballPath, getLocalUpdateVersion, isRunningFromSource, shouldStopAutostartBeforeUpdate } from '../lib/update.js'
 import { buildOpencodeHeaders, buildOpencodeProjectId, buildProviderRequestHeaders, extractOllamaModelRecords, getAccountStatus, getPinnedModelCandidate, getPinnedModelMatches, isProviderAuthOptional, isProviderBearerAuthEnabled, providerWantsBearerAuth, shouldRetryOptionalProviderWithBearer, toOllamaModelMeta, toOpenCodeModelMeta, toOpenRouterModelMeta, toKiloCodeModelMeta } from '../lib/server.js'
+import { extractOllamaVisionFlag, extractOpenRouterVisionFlag, isVisionModelByName, messagesContainImageContent, redactImageContentInMessages } from '../lib/vision.js'
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const ROOT = join(__dirname, '..')
 
@@ -1511,6 +1512,113 @@ describe('multi-account round-robin', () => {
       assert.equal(entry.currentIdx, 1)
       assert.equal(entry.accounts.get(0).requests, 1)
       assert.equal(entry.accounts.get(1).requests, 0)
+    })
+  })
+})
+
+describe('vision capability detection', () => {
+  describe('isVisionModelByName', () => {
+    it('matches common vision suffixes', () => {
+      assert.equal(isVisionModelByName('qwen/qwen3-vl-235b-a22b'), true)
+      assert.equal(isVisionModelByName('xiaomi/mimo-v2-omni'), true)
+      assert.equal(isVisionModelByName('nvidia/nemotron-nano-12b-v2-vl'), true)
+      assert.equal(isVisionModelByName('some-vision-model'), true)
+    })
+
+    it('does not match unrelated names', () => {
+      assert.equal(isVisionModelByName('moonshotai/kimi-k2.5'), false)
+      assert.equal(isVisionModelByName('deepseek-ai/deepseek-v3.2'), false)
+      assert.equal(isVisionModelByName('llama-3.3-70b-versatile'), false)
+      assert.equal(isVisionModelByName(''), false)
+      assert.equal(isVisionModelByName(null), false)
+    })
+  })
+
+  describe('extractOpenRouterVisionFlag', () => {
+    it('reads architecture.input_modalities', () => {
+      assert.equal(
+        extractOpenRouterVisionFlag({ architecture: { input_modalities: ['text', 'image'] } }),
+        true
+      )
+      assert.equal(
+        extractOpenRouterVisionFlag({ architecture: { input_modalities: ['text'] } }),
+        false
+      )
+    })
+
+    it('falls back to modality string', () => {
+      assert.equal(extractOpenRouterVisionFlag({ architecture: { modality: 'text+image->text' } }), true)
+      assert.equal(extractOpenRouterVisionFlag({ modality: 'text->text' }), false)
+    })
+
+    it('returns null when no modality info is present', () => {
+      assert.equal(extractOpenRouterVisionFlag({}), null)
+      assert.equal(extractOpenRouterVisionFlag(null), null)
+    })
+  })
+
+  describe('extractOllamaVisionFlag', () => {
+    it('reads capabilities array', () => {
+      assert.equal(extractOllamaVisionFlag({ capabilities: ['vision', 'tools'] }), true)
+      assert.equal(extractOllamaVisionFlag({ capabilities: ['tools'] }), false)
+    })
+
+    it('returns null when capabilities are missing', () => {
+      assert.equal(extractOllamaVisionFlag({}), null)
+      assert.equal(extractOllamaVisionFlag(null), null)
+    })
+  })
+
+  describe('messagesContainImageContent', () => {
+    it('detects image_url parts', () => {
+      const messages = [
+        { role: 'user', content: [
+          { type: 'text', text: 'What is this?' },
+          { type: 'image_url', image_url: { url: 'data:image/png;base64,AAAA' } },
+        ] },
+      ]
+      assert.equal(messagesContainImageContent(messages), true)
+    })
+
+    it('detects input_image parts', () => {
+      assert.equal(messagesContainImageContent([
+        { role: 'user', content: [{ type: 'input_image', image: { url: 'x' } }] },
+      ]), true)
+    })
+
+    it('returns false for plain text', () => {
+      assert.equal(messagesContainImageContent([
+        { role: 'user', content: 'hello' },
+      ]), false)
+      assert.equal(messagesContainImageContent([
+        { role: 'user', content: [{ type: 'text', text: 'hi' }] },
+      ]), false)
+    })
+
+    it('handles bad input gracefully', () => {
+      assert.equal(messagesContainImageContent(null), false)
+      assert.equal(messagesContainImageContent('not-an-array'), false)
+    })
+  })
+
+  describe('redactImageContentInMessages', () => {
+    it('replaces image parts with placeholders', () => {
+      const messages = [
+        { role: 'user', content: [
+          { type: 'text', text: 'caption please' },
+          { type: 'image_url', image_url: { url: 'data:image/png;base64,VERYLONG' } },
+        ] },
+      ]
+      const redacted = redactImageContentInMessages(messages)
+      assert.equal(redacted[0].content[0].text, 'caption please')
+      assert.equal(redacted[0].content[1].image_url.url, '[image redacted]')
+      // Original is untouched
+      assert.equal(messages[0].content[1].image_url.url, 'data:image/png;base64,VERYLONG')
+    })
+
+    it('leaves text-only messages unchanged', () => {
+      const messages = [{ role: 'user', content: 'hi' }]
+      assert.equal(redactImageContentInMessages(messages)[0], messages[0])
     })
   })
 })


### PR DESCRIPTION
## Summary

- Detects multimodal requests (`image_url` / `input_image` content parts) and routes only to vision-capable models. Pinned text-only models with image input now get a clear 400 instead of being passed through to fail upstream.
- Resolves vision capability automatically (no manually maintained list):
  - **OpenRouter `/api/v1/models`** as the cross-provider truth source via `architecture.input_modalities`. Re-uses the existing periodic catalog refresh; even when OpenRouter routing is disabled, the catalog fetch still populates the modality index so other providers (NVIDIA, Groq, Cerebras, Scaleway, Google AI, ...) inherit accurate flags.
  - **Ollama `capabilities`** array on per-model records.
  - **Name heuristic** (`vl` / `vision` / `omni` / `multimodal` / `mm`) as a last-resort fallback.
- Redacts image content from the terminal log and the in-memory request log so base64 payloads don't bloat logs or memory.

## Why

The relay forwarded the payload verbatim, so multimodal `messages` mechanically passed through, but `auto-fastest` had no notion of image capability and would route image requests to text-only models. This change makes `auto-fastest` modality-aware and protects users from confusing upstream errors.

## Files

- `lib/vision.js` — new module with pure helpers (`messagesContainImageContent`, `redactImageContentInMessages`, `extractOpenRouterVisionFlag`, `extractOllamaVisionFlag`, `isVisionModelByName`).
- `lib/server.js` — splits `fetchOpenRouterFreeModels` into `fetchOpenRouterModelCatalog` (returns `{ freeModels, visionMap }`); maintains an `openRouterVisionMap` and per-record overrides, applied on every refresh; gates routing in `/v1/chat/completions` on detected image input.
- `test/test.js` — unit tests for the new pure helpers.

## Test plan

- [x] `npm test` — 152/152 passing (added 13 tests across 5 suites for the new helpers).
- [x] Local run: `auto-fastest` with images narrows to vision-capable candidates; pinning `llama-3.3-70b-versatile` with images returns a descriptive 400.
- [x] `/api/logs` shows `[image redacted]` in place of base64 image data.
- [ ] Verify against a live provider end-to-end (couldn't do this on the dev box — no provider keys configured).

🤖 Generated with [Claude Code](https://claude.com/claude-code)