### PR TITLE
Retry sooner after a failed discovery/model-sync attempt

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -8,7 +8,7 @@ import { MODELS, sources, canonicalizeModelId, getPreferredModelContext, getPref
 import { getModelTags as getBuiltInModelTags } from '../tags.js';
 import { API_KEY_SIGNUP_URLS } from './providerLinks.js';
 import { getApiKey, getApiKeyPool, getMaxTurns, getPinningMode, getProviderBaseUrl, getProviderModelId, hasMultipleKeys, isProviderEnabled, getProviderPingIntervalMs, isAutoPingEnabled, loadConfig, saveConfig, exportConfigToken, importConfigToken, isOpenAICompatibleInstanceKey, getBaseProviderKey, listOpenAICompatibleEndpoints, upsertOpenAICompatibleEndpoint, removeOpenAICompatibleEndpoint, buildOpenAICompatibleInstanceKey, getOpenAICompatibleInstanceId } from './config.js';
-import { buildModelGroups, computeQoSMap, findBestModel, getAvg, getUptime, getVerdict, isRetryableProxyStatus, rankModelsForRouting, getRoutingModelKey, parseOpenRouterKeyRateLimit, filterModelsByRequested, selectNextApiKeyFromPool } from './utils.js';
+import { buildModelGroups, computeFailedRefreshRetryAt, computeQoSMap, findBestModel, getAvg, getUptime, getVerdict, isRetryableProxyStatus, rankModelsForRouting, getRoutingModelKey, parseOpenRouterKeyRateLimit, filterModelsByRequested, selectNextApiKeyFromPool } from './utils.js';
 import { getPreferredLanIpv4Address } from './network.js';
 import { createHash, randomUUID } from 'crypto';
 import { getAutostartStatus } from './autostart.js';
@@ -49,6 +49,10 @@ const KIRO_PROVIDER_KEY = 'kiro';
 const OPENROUTER_MODELS_URL = 'https://openrouter.ai/api/v1/models';
 const OPENROUTER_MODELS_REFRESH_MS = 60 * 60_000;
 const DISCOVERABLE_PROVIDER_MODELS_REFRESH_MS = 30 * 60_000;
+// A failed discovery/model-sync attempt shouldn't be locked out for the full success TTL --
+// that turns one transient network blip into up to an hour of an empty/stale model list with
+// no automatic recovery. Retry again after this much shorter backoff instead.
+const FAILED_DISCOVERY_RETRY_MS = 2 * 60_000;
 const OPTIONAL_BEARER_AUTH_PROVIDERS = new Set([KILOCODE_PROVIDER_KEY, OPENCODE_PROVIDER_KEY]);
 const OPENCODE_CLIENT_HEADER = 'cli';
 // Kiro expects AWS SDK-style user-agent headers (mirrors OmniRoute's Kiro header profile).
@@ -2452,12 +2456,12 @@ export async function runServer(config, port, enableLog = true, bannedModels = [
       }
       const models = await fetchKiloCodeFreeModels(currentConfig);
       mergeDynamicProviderModels(KILOCODE_PROVIDER_KEY, models);
+      lastKiloCodeModelRefreshAt = Date.now();
       return models;
     } catch (err) {
       console.log(chalk.dim(`  [KiloCode] Model sync skipped: ${describeSyncError(err)}`));
+      lastKiloCodeModelRefreshAt = computeFailedRefreshRetryAt(Date.now(), KILOCODE_MODELS_REFRESH_MS, FAILED_DISCOVERY_RETRY_MS);
       throw err;
-    } finally {
-      lastKiloCodeModelRefreshAt = Date.now();
     }
   };
 
@@ -2472,12 +2476,12 @@ export async function runServer(config, port, enableLog = true, bannedModels = [
       }
       const models = await fetchOpenCodeModels(currentConfig);
       mergeDynamicProviderModels(OPENCODE_PROVIDER_KEY, models);
+      lastOpenCodeModelRefreshAt = Date.now();
       return models;
     } catch (err) {
       console.log(chalk.dim(`  [OpenCode Zen] Model sync skipped: ${describeSyncError(err)}`));
+      lastOpenCodeModelRefreshAt = computeFailedRefreshRetryAt(Date.now(), OPENCODE_MODELS_REFRESH_MS, FAILED_DISCOVERY_RETRY_MS);
       throw err;
-    } finally {
-      lastOpenCodeModelRefreshAt = Date.now();
     }
   };
 
@@ -2492,12 +2496,12 @@ export async function runServer(config, port, enableLog = true, bannedModels = [
       }
       const models = await fetchOpenRouterFreeModels(currentConfig);
       mergeDynamicProviderModels(OPENROUTER_PROVIDER_KEY, models);
+      lastOpenRouterModelRefreshAt = Date.now();
       return models;
     } catch (err) {
       console.log(chalk.dim(`  [OpenRouter] Model sync skipped: ${describeSyncError(err)}`));
+      lastOpenRouterModelRefreshAt = computeFailedRefreshRetryAt(Date.now(), OPENROUTER_MODELS_REFRESH_MS, FAILED_DISCOVERY_RETRY_MS);
       throw err;
-    } finally {
-      lastOpenRouterModelRefreshAt = Date.now();
     }
   };
 
@@ -2584,14 +2588,14 @@ export async function runServer(config, port, enableLog = true, bannedModels = [
         ? [fallbackModel, ...discovered.filter(m => m.modelId !== fallbackModel.modelId)]
         : discovered;
       mergeDynamicProviderModels(OLLAMA_PROVIDER_KEY, models);
+      lastOllamaModelRefreshAt = Date.now();
       return models;
     } catch (err) {
       const fallbackModel = buildOllamaModelMeta(currentConfig);
       mergeDynamicProviderModels(OLLAMA_PROVIDER_KEY, fallbackModel ? [fallbackModel] : []);
       console.log(chalk.dim(`  [Ollama] Model sync skipped: ${describeSyncError(err)}`));
+      lastOllamaModelRefreshAt = computeFailedRefreshRetryAt(Date.now(), OLLAMA_MODELS_REFRESH_MS, FAILED_DISCOVERY_RETRY_MS);
       throw err;
-    } finally {
-      lastOllamaModelRefreshAt = Date.now();
     }
   };
 
@@ -2643,17 +2647,18 @@ export async function runServer(config, port, enableLog = true, bannedModels = [
 
       if (models.length === 0) {
         console.log(chalk.dim(`  [${source.name}] No models discovered via /v1/models, keeping hardcoded list`));
+        lastDiscoverableProviderDiscoveryAt.set(providerKey, Date.now());
         return [];
       }
 
       mergeDiscoverableProviderModels(providerKey, models);
       console.log(chalk.green(`  ✓ [${source.name}] Discovered ${models.length} models via /v1/models`));
+      lastDiscoverableProviderDiscoveryAt.set(providerKey, Date.now());
       return models;
     } catch (err) {
       console.log(chalk.dim(`  [${source.name}] Model discovery skipped: ${describeSyncError(err)}, using hardcoded list`));
+      lastDiscoverableProviderDiscoveryAt.set(providerKey, computeFailedRefreshRetryAt(Date.now(), DISCOVERABLE_PROVIDER_MODELS_REFRESH_MS, FAILED_DISCOVERY_RETRY_MS));
       return [];
-    } finally {
-      lastDiscoverableProviderDiscoveryAt.set(providerKey, Date.now());
     }
   };
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -394,6 +394,17 @@ export function isRetryableProxyStatus(status) {
   return code === 429 || code === 410 || code >= 500
 }
 
+/**
+ * Computes the "last refreshed at" timestamp to record after a *failed* discovery/model-sync
+ * attempt, so the next TTL check allows a retry after `retryBackoffMs` instead of waiting out
+ * the full `refreshIntervalMs` success TTL. Without this, one transient network failure gets
+ * treated the same as a successful refresh and silently locks out automatic retries for the
+ * whole TTL window (up to an hour, depending on the provider) until a manual force-refresh.
+ */
+export function computeFailedRefreshRetryAt(now, refreshIntervalMs, retryBackoffMs) {
+  return now - refreshIntervalMs + retryBackoffMs
+}
+
 export function parseArgs(argv) {
   const args = argv.slice(2)
   const firstCommandToken = args.find(a => !a.startsWith('--'))

--- a/test/test.js
+++ b/test/test.js
@@ -18,6 +18,7 @@ import {
   buildModelGroups,
   filterModelsByRequested,
   isRetryableProxyStatus,
+  computeFailedRefreshRetryAt,
   parseArgs,
   parseOpenRouterKeyRateLimit,
   selectNextApiKeyFromPool,
@@ -1610,6 +1611,34 @@ describe('isRetryableProxyStatus', () => {
     assert.equal(isRetryableProxyStatus(400), false)
     assert.equal(isRetryableProxyStatus(404), false)
     assert.equal(isRetryableProxyStatus('not-a-status'), false)
+  })
+})
+
+describe('computeFailedRefreshRetryAt', () => {
+  it('allows a retry after retryBackoffMs instead of the full refresh TTL', () => {
+    const now = 1_000_000_000
+    const refreshIntervalMs = 60 * 60_000 // 1 hour, e.g. OpenCode Zen's TTL
+    const retryBackoffMs = 2 * 60_000 // 2 minutes
+    const stampedAt = computeFailedRefreshRetryAt(now, refreshIntervalMs, retryBackoffMs)
+
+    // Immediately after the failure, the TTL guard (`now - stampedAt < refreshIntervalMs`)
+    // must still say "not yet" -- otherwise every failure would retry on every ping cycle.
+    assert.equal((now - stampedAt) < refreshIntervalMs, true)
+    assert.ok((now - stampedAt) >= refreshIntervalMs - retryBackoffMs)
+
+    // retryBackoffMs later, the TTL guard must allow a retry.
+    const afterBackoff = now + retryBackoffMs
+    assert.equal((afterBackoff - stampedAt) >= refreshIntervalMs, true)
+
+    // Just before retryBackoffMs elapses, it must still be blocked.
+    const justBefore = now + retryBackoffMs - 1
+    assert.equal((justBefore - stampedAt) >= refreshIntervalMs, false)
+  })
+
+  it('never returns a timestamp in the future relative to a fresh success stamp', () => {
+    const now = Date.now()
+    const stampedAt = computeFailedRefreshRetryAt(now, 30 * 60_000, 2 * 60_000)
+    assert.ok(stampedAt < now)
   })
 })
 


### PR DESCRIPTION
## Summary
- `refreshKiloCodeModels`, `refreshOpenCodeModels`, `refreshOpenRouterModels`, `refreshOllamaModels`, and `refreshDiscoverableProviderModels` all stamped their "last refreshed" timestamp in a `finally` block, so a single transient failure (network blip, timeout) was treated identically to a success for TTL purposes — silently locking out automatic retries for up to an hour until a manual force-refresh.
- This is especially bad for OpenCode Zen, whose static model list in `sources.js` is empty (`models: []`), so one failed fetch means zero models shown for the full hour with no automatic recovery.
- Moved the success stamp into the `try` block and added a much shorter retry backoff (2 min) on failure, via a new `computeFailedRefreshRetryAt` helper in `lib/utils.js`.

## Why a separate helper function
The affected refresh functions are internal closures inside `runServer()`, not easily unit-testable in isolation without mocking the whole server/fetch stack. Extracted the actual retry-timing math into a small pure function (matching the existing convention of keeping computations like `getAvg`/`computeQoS` in `lib/utils.js`) so the fix has direct test coverage instead of being untested.

## Test plan
- [x] `npm test` — 208/208 passing (206 existing + 2 new for `computeFailedRefreshRetryAt`)
- [x] `node --check lib/server.js`