### PR TITLE
Add min_ctx modifier for tag: and auto-fastest requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ modelrelay config export | modelrelay config import
 - Use a grouped model ID such as `minimax-m2.5`, `kimi-k2.5`, or `glm4.7` to route within that model group
 - For grouped IDs, modelrelay selects the provider with the best current QoS for that group
 - Use `model: "tag:<name>"` (e.g. `tag:coding`) to route to the best currently available model carrying that tag — either a curated capability tag or a custom tag you've assigned in the Web UI (see [Model tags](#model-tags)). This is useful because the free models behind modelrelay come and go as availability changes — routing by tag survives a given model disappearing, where routing by a specific model/group ID does not.
+- Append `+min_ctx:<size>` to `tag:<name>` or `auto-fastest` to additionally require a minimum context window, e.g. `tag:general+min_ctx:32000` or `auto-fastest+min_ctx:128k`. `<size>` accepts a raw token count or a `k`/`m` suffix. Models whose context window can't be determined, or is smaller than the requirement, are excluded. See [Model tags](#model-tags).
 - In the Web UI, pinned models can now use either `Canonical Group` mode (default, pins the same model across providers) or `Exact Provider Row` mode from `Settings`
 - Streaming and non-streaming requests are both supported
 
@@ -214,6 +215,16 @@ Every model carries one or more capability tags, combined from two sources:
 - **Custom tags** are freeform labels you assign yourself. In the Web UI, open a model row and edit **Custom Routing Tags**. Assignments are keyed to the canonical model, shared across its providers, and stored in `~/.modelrelay.json`.
 
 Use `model: "tag:<name>"` in `/v1/chat/completions` to route to the best currently available model carrying that tag — curated or custom — instead of naming a specific model. For example, assign `coding` to a few models in the UI, then request `model: "tag:coding"`; normal QoS ranking, availability filtering, and retry behavior choose the best currently eligible tagged model.
+
+#### Minimum context window (`min_ctx`)
+
+Tag membership alone doesn't guarantee a model can fit your prompt — a tag can span models with very different context windows. Append `+min_ctx:<size>` to filter those out before QoS ranking runs:
+
+- `tag:general+min_ctx:32000` — best available `general`-tagged model with at least 32,000 tokens of context
+- `tag:coding+min_ctx:128k` — same, for `coding`, using the `k` shorthand
+- `auto-fastest+min_ctx:1m` — fastest model overall with at least 1,000,000 tokens of context, no tag restriction
+
+`<size>` accepts a plain token count (`32000`) or a `k`/`m` suffix (`32k`, `1m`). Models with no known context window, or a smaller one than requested, are excluded from consideration. An unparseable or unrecognized modifier is ignored, falling back to the unmodified `tag:<name>` or `auto-fastest` behavior rather than erroring.
 
 ## Config
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -357,16 +357,90 @@ export function buildModelGroups(results, canonicalizeFn) {
 
 const TAG_REQUEST_PREFIX = 'tag:'
 
+/**
+ * Parses a human-readable context-size string ("128k", "1m", "32000") into a raw token count.
+ * Returns null for anything unparseable/empty. Used by the `tag:<name>+min_ctx:<n>` request
+ * syntax to filter out models whose context window can't fit the caller's stated requirement.
+ */
+export function parseContextSize(value) {
+  if (value == null) return null
+  if (typeof value === 'number') return Number.isFinite(value) && value >= 0 ? Math.round(value) : null
+
+  const str = String(value).trim().toLowerCase()
+  if (!str || str === '—') return null
+
+  if (str.endsWith('m')) {
+    const num = parseFloat(str)
+    return Number.isFinite(num) ? Math.round(num * 1_000_000) : null
+  }
+  if (str.endsWith('k')) {
+    const num = parseFloat(str)
+    return Number.isFinite(num) ? Math.round(num * 1_000) : null
+  }
+  const num = parseFloat(str)
+  return Number.isFinite(num) ? Math.round(num) : null
+}
+
+/**
+ * Parses `+`-delimited `key:value` modifiers, e.g. the `min_ctx:32000` in
+ * `tag:general+min_ctx:32000` or `auto-fastest+min_ctx:128k`. Unknown modifier keys are
+ * ignored rather than rejected, so new modifiers can be added later without breaking older
+ * callers or requiring a new reserved prefix per modifier.
+ */
+function parseModifiers(parts) {
+  let minCtx = null
+  for (const part of parts) {
+    const sepIdx = part.indexOf(':')
+    if (sepIdx === -1) continue
+    const key = part.slice(0, sepIdx).trim()
+    const value = part.slice(sepIdx + 1).trim()
+    if (key === 'min_ctx' && value) {
+      const parsed = parseContextSize(value)
+      if (parsed != null) minCtx = parsed
+    }
+  }
+  return { minCtx }
+}
+
+/**
+ * Parses a `tag:<name>[+modifier...]` request. The tag name is always the first
+ * `+`-delimited segment; anything after that is passed to parseModifiers().
+ */
+function parseTagRequest(rest) {
+  const parts = String(rest || '').split('+').map(s => s.trim()).filter(Boolean)
+  const tag = parts[0] || ''
+  const { minCtx } = parseModifiers(parts.slice(1))
+  return { tag, minCtx }
+}
+
+function matchesMinCtx(result, minCtx) {
+  if (minCtx == null) return true
+  const resultCtx = parseContextSize(result.ctx)
+  return resultCtx != null && resultCtx >= minCtx
+}
+
 export function filterModelsByRequested(results, requestedModel, canonicalizeFn) {
-  if (!requestedModel || requestedModel === 'auto-fastest') return results
+  if (!requestedModel) return results
 
   const requested = normalizeModelAlias(requestedModel)
-  if (requested.startsWith('tag:')) {
-    const tag = requested.slice(4).trim()
+  if (requested === 'auto-fastest') return results
+
+  // auto-fastest+min_ctx:<n>: same QoS-driven "fastest" selection as auto-fastest, but
+  // restricted to models that can actually fit a prompt of the caller's stated size --
+  // see https://github.com/ellipticmarketing/modelrelay/issues/42.
+  if (requested.startsWith('auto-fastest+')) {
+    const parts = requested.slice('auto-fastest+'.length).split('+').map(s => s.trim()).filter(Boolean)
+    const { minCtx } = parseModifiers(parts)
+    if (minCtx == null) return results
+    return results.filter(result => matchesMinCtx(result, minCtx))
+  }
+
+  if (requested.startsWith(TAG_REQUEST_PREFIX)) {
+    const { tag, minCtx } = parseTagRequest(requested.slice(TAG_REQUEST_PREFIX.length))
     if (!tag) return []
     return results.filter(result => {
       const tags = [...getBuiltInModelTags(result.modelId), ...(Array.isArray(result.tags) ? result.tags : [])]
-      return tags.includes(tag)
+      return tags.includes(tag) && matchesMinCtx(result, minCtx)
     })
   }
   const providerQualifiedMatches = results.filter(r => getRoutingModelKey(r) === requested)

--- a/test/test.js
+++ b/test/test.js
@@ -19,6 +19,7 @@ import {
   filterModelsByRequested,
   isRetryableProxyStatus,
   computeFailedRefreshRetryAt,
+  parseContextSize,
   parseArgs,
   parseOpenRouterKeyRateLimit,
   selectNextApiKeyFromPool,
@@ -987,6 +988,75 @@ describe('user-defined model tags', () => {
     assert.deepEqual(filterModelsByRequested(results, 'tag:'), [])
   })
 
+  it('filters tag requests by a min_ctx modifier', () => {
+    const results = [
+      mockResult({ modelId: 'small', tags: ['general'], ctx: '8k' }),
+      mockResult({ modelId: 'medium', tags: ['general'], ctx: '32k' }),
+      mockResult({ modelId: 'large', tags: ['general'], ctx: '1m' }),
+      mockResult({ modelId: 'no-ctx', tags: ['general'], ctx: null }),
+      mockResult({ modelId: 'wrong-tag', tags: ['coding'], ctx: '1m' }),
+    ]
+
+    assert.deepEqual(
+      filterModelsByRequested(results, 'tag:general+min_ctx:32000').map(m => m.modelId),
+      ['medium', 'large'],
+    )
+    // Exact boundary: a 32k model satisfies a 32000-token floor.
+    assert.deepEqual(
+      filterModelsByRequested(results, 'tag:general+min_ctx:32001').map(m => m.modelId),
+      ['large'],
+    )
+    // Shorthand k/m suffixes on the modifier value itself.
+    assert.deepEqual(
+      filterModelsByRequested(results, 'tag:general+min_ctx:1m').map(m => m.modelId),
+      ['large'],
+    )
+    // No modifier -- unchanged plain tag behavior, unparseable/missing ctx included.
+    assert.deepEqual(
+      filterModelsByRequested(results, 'tag:general').map(m => m.modelId),
+      ['small', 'medium', 'large', 'no-ctx'],
+    )
+  })
+
+  it('ignores unknown or malformed tag modifiers instead of rejecting the request', () => {
+    const results = [mockResult({ modelId: 'one', tags: ['general'], ctx: '128k' })]
+    assert.deepEqual(
+      filterModelsByRequested(results, 'tag:general+unknown_modifier:whatever').map(m => m.modelId),
+      ['one'],
+    )
+    assert.deepEqual(
+      filterModelsByRequested(results, 'tag:general+min_ctx:not-a-number').map(m => m.modelId),
+      ['one'],
+    )
+    assert.deepEqual(
+      filterModelsByRequested(results, 'tag:general+').map(m => m.modelId),
+      ['one'],
+    )
+  })
+
+  it('filters auto-fastest by min_ctx regardless of capability tags (issue #42)', () => {
+    const results = [
+      mockResult({ modelId: 'small', tags: ['general'], ctx: '8k' }),
+      mockResult({ modelId: 'medium', tags: ['coding'], ctx: '128k' }),
+      mockResult({ modelId: 'large', ctx: '1m' }), // no tags at all -- still eligible
+    ]
+
+    assert.deepEqual(
+      filterModelsByRequested(results, 'auto-fastest+min_ctx:128k').map(m => m.modelId),
+      ['medium', 'large'],
+    )
+    // Plain auto-fastest is untouched -- still returns everything, unfiltered.
+    assert.deepEqual(
+      filterModelsByRequested(results, 'auto-fastest').map(m => m.modelId),
+      ['small', 'medium', 'large'],
+    )
+    // A malformed/unknown modifier falls back to plain auto-fastest behavior.
+    assert.deepEqual(
+      filterModelsByRequested(results, 'auto-fastest+bogus:xyz').map(m => m.modelId),
+      ['small', 'medium', 'large'],
+    )
+  })
+
   it('normalizes persisted model tags safely', () => {
     const normalized = normalizeConfigShape({
       modelTags: {
@@ -1639,6 +1709,30 @@ describe('computeFailedRefreshRetryAt', () => {
     const now = Date.now()
     const stampedAt = computeFailedRefreshRetryAt(now, 30 * 60_000, 2 * 60_000)
     assert.ok(stampedAt < now)
+  })
+})
+
+describe('parseContextSize', () => {
+  it('parses k and m suffixes into raw token counts', () => {
+    assert.equal(parseContextSize('128k'), 128_000)
+    assert.equal(parseContextSize('1m'), 1_000_000)
+    assert.equal(parseContextSize('1M'), 1_000_000)
+    assert.equal(parseContextSize('10M'), 10_000_000)
+    assert.equal(parseContextSize('0.5m'), 500_000)
+  })
+
+  it('parses plain numbers, string or numeric', () => {
+    assert.equal(parseContextSize('32000'), 32_000)
+    assert.equal(parseContextSize(32000), 32_000)
+  })
+
+  it('returns null for unparseable, empty, or negative input', () => {
+    assert.equal(parseContextSize(null), null)
+    assert.equal(parseContextSize(undefined), null)
+    assert.equal(parseContextSize(''), null)
+    assert.equal(parseContextSize('—'), null)
+    assert.equal(parseContextSize('not-a-number'), null)
+    assert.equal(parseContextSize(-5), null)
   })
 })
 


### PR DESCRIPTION
## Summary

Closes #42 with a slightly more general design than the one proposed there.

Tag membership alone doesn't guarantee a model can fit a given prompt — a tag can span models with wildly different context windows. Hit this in practice routing scheduled/cron jobs through `tag:general`: it landed on a model with only an 8k context window for a ~30k-token prompt, and there was no way to express "and it needs to actually fit."

## What this adds

A `+min_ctx:<size>` modifier usable on both `tag:<name>` and `auto-fastest`:

- `tag:general+min_ctx:32000` — best available `general`-tagged model with at least 32,000 tokens of context
- `auto-fastest+min_ctx:128k` — fastest model overall with at least 128k context, no tag restriction — this is the exact use case from #42

`<size>` accepts a raw token count or a `k`/`m` suffix. Models with no known context window, or a smaller one than requested, are excluded from consideration before QoS ranking runs. An unparseable/unknown modifier is ignored rather than rejected, falling back to plain `tag:<name>`/`auto-fastest` behavior instead of erroring.

## Why a composable modifier instead of `auto-context32`/`auto-context128`/etc.

#42 proposed fixed router names for a set of context sizes. Went with a composable `+min_ctx:<n>` modifier instead because:
- It works with capability tags too (`tag:coding+min_ctx:128k`), not just `auto-fastest` — a fixed enum of context-only routers can't express "coding model with at least 128k."
- No enum to maintain/extend as new context sizes become relevant (`auto-context32/128/256/1m` — what about 64k or 512k?).
- Same `key:value` modifier shape can carry future filters beyond context without inventing a new reserved prefix each time.

Happy to add `auto-context<N>` aliases mapping onto this if you'd still prefer that surface for discoverability — figured I'd open this for discussion first rather than guess.

## Test plan
- [x] `npm test` — 215/215 passing (210 existing baseline on this branch + 5 new: `parseContextSize` behavior, `tag:` + `min_ctx` filtering, `auto-fastest` + `min_ctx` filtering, malformed-modifier fallback)
- [x] `node --check lib/utils.js`