### PR TITLE
Use provider context data for routing and add minimum-context filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ modelrelay config export | modelrelay config import
 - Use a grouped model ID such as `minimax-m2.5`, `kimi-k2.5`, or `glm4.7` to route within that model group
 - For grouped IDs, modelrelay selects the provider with the best current QoS for that group
 - Use `model: "tag:<name>"` (e.g. `tag:coding`) to route to the best currently available model carrying that tag — either a curated capability tag or a custom tag you've assigned in the Web UI (see [Model tags](#model-tags)). This is useful because the free models behind modelrelay come and go as availability changes — routing by tag survives a given model disappearing, where routing by a specific model/group ID does not.
+- Append `+min_ctx:<size>` to `tag:<name>` or `auto-fastest` to additionally require a minimum context window, e.g. `tag:general+min_ctx:32000` or `auto-fastest+min_ctx:128k`. `<size>` accepts a raw token count or a `k`/`m` suffix. Models whose context window can't be determined, or is smaller than the requirement, are excluded. See [Model tags](#model-tags).
 - In the Web UI, pinned models can now use either `Canonical Group` mode (default, pins the same model across providers) or `Exact Provider Row` mode from `Settings`
 - Streaming and non-streaming requests are both supported
 
@@ -214,6 +215,16 @@ Every model carries one or more capability tags, combined from two sources:
 - **Custom tags** are freeform labels you assign yourself. In the Web UI, open a model row and edit **Custom Routing Tags**. Assignments are keyed to the canonical model, shared across its providers, and stored in `~/.modelrelay.json`.
 
 Use `model: "tag:<name>"` in `/v1/chat/completions` to route to the best currently available model carrying that tag — curated or custom — instead of naming a specific model. For example, assign `coding` to a few models in the UI, then request `model: "tag:coding"`; normal QoS ranking, availability filtering, and retry behavior choose the best currently eligible tagged model.
+
+#### Minimum context window (`min_ctx`)
+
+Tag membership alone doesn't guarantee a model can fit your prompt — a tag can span models with very different context windows. Append `+min_ctx:<size>` to filter those out before QoS ranking runs:
+
+- `tag:general+min_ctx:32000` — best available `general`-tagged model with at least 32,000 tokens of context
+- `tag:coding+min_ctx:128k` — same, for `coding`, using the `k` shorthand
+- `auto-fastest+min_ctx:1m` — fastest model overall with at least 1,000,000 tokens of context, no tag restriction
+
+`<size>` accepts a plain token count (`32000`) or a `k`/`m` suffix (`32k`, `1m`). Models with no known context window, or a smaller one than requested, are excluded from consideration. An unparseable or unrecognized modifier is ignored, falling back to the unmodified `tag:<name>` or `auto-fastest` behavior rather than erroring.
 
 ## Config
 

--- a/README.md
+++ b/README.md
@@ -226,6 +226,8 @@ Tag membership alone doesn't guarantee a model can fit your prompt — a tag can
 
 `<size>` accepts a plain token count (`32000`) or a `k`/`m` suffix (`32k`, `1m`). Models with no known context window, or a smaller one than requested, are excluded from consideration. An unparseable or unrecognized modifier is ignored, falling back to the unmodified `tag:<name>` or `auto-fastest` behavior rather than erroring.
 
+Modelrelay uses context data reported by the selected provider when it is available. Otherwise, it uses a provider-specific curated value from `sources.js`. It does not copy a context size between providers. It also keeps the context unknown when neither source has a value. For Ollama, the allocated or configured context is usable for this filter. The model maximum alone is not sufficient.
+
 ## Config
 
 - Router config file: `~/.modelrelay.json`

--- a/lib/server.js
+++ b/lib/server.js
@@ -78,20 +78,19 @@ const KIRO_BROWSER_AUTH_PROVIDERS = new Set(['google', 'github']);
 const KIRO_MAX_CONTEXT_TOKENS = 200_000; // Kiro/Claude model max context window for usage estimation
 
 const DEFAULT_DYNAMIC_MODEL_INTELL = DEFAULT_MODEL_QUALITY;
-const DEFAULT_DYNAMIC_MODEL_CTX = '128k';
 const EXCLUDED_DYNAMIC_MODEL_BASE_IDS = new Set([
   'meta-llama/llama-guard-4-12b',
   'nvidia/nemotron-3.5-content-safety',
 ]);
 
 const OPENCODE_CHAT_COMPLETIONS_MODELS = new Map([
-  ['minimax-m2.5-free', { label: 'MiniMax M2.5 Free', ctx: '128k', scoreId: 'minimax/minimax-m2.5' }],
-  ['qwen3.6-plus-free', { label: 'Qwen3.6 Plus', ctx: '128k', scoreId: 'qwen/qwen3.5-397b-a17b' }],
-  ['trinity-large-preview-free', { label: 'Trinity Large Preview', ctx: '128k', scoreId: 'arcee-ai/trinity-large-preview' }],
-  ['mimo-v2-flash-free', { label: 'MiMo V2 Flash', ctx: '128k', scoreId: null }],
-  ['mimo-v2-pro-free', { label: 'MiMo V2 Omni Pro', ctx: '128k', scoreId: 'xiaomi/mimo-v2-pro' }],
-  ['mimo-v2-omni-free', { label: 'MiMo V2 Omni', ctx: '128k', scoreId: 'xiaomi/mimo-v2-omni' }],
-  ['nemotron-3-super-free', { label: 'Nemotron 3 Super Free', ctx: '128k', scoreId: 'nvidia/nemotron-3-super-120b-a12b' }],
+  ['minimax-m2.5-free', { label: 'MiniMax M2.5 Free', scoreId: 'minimax/minimax-m2.5' }],
+  ['qwen3.6-plus-free', { label: 'Qwen3.6 Plus', scoreId: 'qwen/qwen3.5-397b-a17b' }],
+  ['trinity-large-preview-free', { label: 'Trinity Large Preview', scoreId: 'arcee-ai/trinity-large-preview' }],
+  ['mimo-v2-flash-free', { label: 'MiMo V2 Flash', scoreId: null }],
+  ['mimo-v2-pro-free', { label: 'MiMo V2 Omni Pro', scoreId: 'xiaomi/mimo-v2-pro' }],
+  ['mimo-v2-omni-free', { label: 'MiMo V2 Omni', scoreId: 'xiaomi/mimo-v2-omni' }],
+  ['nemotron-3-super-free', { label: 'Nemotron 3 Super Free', scoreId: 'nvidia/nemotron-3-super-120b-a12b' }],
 ]);
 
 function isOpenCodeFreeModelId(modelId) {
@@ -391,7 +390,7 @@ function buildConfigurableProviderModelMeta(config, providerKey, defaultBaseUrl 
   if (!modelId || !baseUrl) return null;
 
   const { base, unprefixed } = canonicalizeModelId(modelId);
-  const known = knownModelMetaMap.get(base) || knownModelMetaMap.get(unprefixed) || null;
+  const known = findKnownModelMeta([base, unprefixed], providerKey);
   const knownScore = normalizeIntelligenceScore(getScore(modelId));
   const hasScore = (knownScore != null && knownScore > 0) || (known != null && known.intell != null);
 
@@ -400,7 +399,9 @@ function buildConfigurableProviderModelMeta(config, providerKey, defaultBaseUrl 
     label: known?.label || formatGenericProviderModelLabel(modelId),
     intell: knownScore ?? known?.intell ?? DEFAULT_DYNAMIC_MODEL_INTELL,
     isEstimatedScore: !hasScore,
-    ctx: known?.ctx || DEFAULT_DYNAMIC_MODEL_CTX,
+    ctx: known?.providerKey === providerKey ? known.ctx : null,
+    ctxSource: known?.providerKey === providerKey ? known.ctxSource : null,
+    ctxSourceUrl: known?.providerKey === providerKey ? known.ctxSourceUrl : null,
     providerKey,
     providerUrl: baseUrl,
   };
@@ -416,13 +417,30 @@ function buildOllamaModelMeta(config) {
 
 function getKnownModelMetaMap() {
   const map = new Map();
-  for (const [modelId, label, intell, ctx] of MODELS) {
-    if (!map.has(modelId)) map.set(modelId, { label, intell, ctx });
+  for (const [modelId, label, intell, ctx, providerKey, ctxSource, ctxSourceUrl] of MODELS) {
+    const meta = { label, intell, ctx, providerKey, ctxSource, ctxSourceUrl };
+    map.set(`${providerKey}:${modelId}`, meta);
+    if (!map.has(modelId)) map.set(modelId, meta);
   }
   return map;
 }
 
 const knownModelMetaMap = getKnownModelMetaMap();
+
+function findKnownModelMeta(ids, providerKey = null) {
+  const values = ids.filter(Boolean);
+  if (providerKey) {
+    for (const id of values) {
+      const match = knownModelMetaMap.get(`${providerKey}:${id}`);
+      if (match) return match;
+    }
+  }
+  for (const id of values) {
+    const match = knownModelMetaMap.get(id);
+    if (match) return match;
+  }
+  return null;
+}
 
 function extractKiloCodeModelRecords(payload) {
   if (Array.isArray(payload)) return payload;
@@ -437,14 +455,31 @@ function extractKiloCodeModelRecords(payload) {
 }
 
 function parseKiloCodeContext(rawCtx) {
-  if (rawCtx == null) return DEFAULT_DYNAMIC_MODEL_CTX;
+  if (rawCtx == null) return null;
   if (typeof rawCtx === 'number' && Number.isFinite(rawCtx) && rawCtx > 0) {
-    if (rawCtx >= 1_000_000) return `${Math.round(rawCtx / 1_000_000)}M`;
-    if (rawCtx >= 1000) return `${Math.round(rawCtx / 1000)}k`;
+    if (rawCtx % 1_000_000 === 0) return `${rawCtx / 1_000_000}M`;
+    if (rawCtx % 1000 === 0) return `${rawCtx / 1000}k`;
     return String(Math.round(rawCtx));
   }
   if (typeof rawCtx === 'string' && rawCtx.trim()) return rawCtx.trim();
-  return DEFAULT_DYNAMIC_MODEL_CTX;
+  return null;
+}
+
+function resolveModelContext(rawCtx, known = null) {
+  const reported = parseKiloCodeContext(rawCtx);
+  if (reported) return { ctx: reported, ctxSource: 'provider-reported', ctxSourceUrl: null };
+  if (known?.ctx) return { ctx: known.ctx, ctxSource: known.ctxSource || 'curated', ctxSourceUrl: known.ctxSourceUrl || null };
+  return { ctx: null, ctxSource: null, ctxSourceUrl: null };
+}
+
+function getReportedContext(record) {
+  if (!record || typeof record !== 'object') return null;
+  return record.context_length
+    ?? record.contextLength
+    ?? record.ctx
+    ?? record.top_provider?.context_length
+    ?? record.limits?.max_context_length
+    ?? null;
 }
 
 function normalizeIntelligenceScore(value) {
@@ -483,7 +518,7 @@ export function toKiloCodeModelMeta(record) {
   if (!modelId || !modelId.endsWith(':free')) return null;
   if (isExcludedDynamicModelId(modelId)) return null;
 
-  const known = knownModelMetaMap.get(modelId) || knownModelMetaMap.get(modelId.replace(/:free$/, '')) || null;
+  const known = findKnownModelMeta([modelId, modelId.replace(/:free$/, '')], KILOCODE_PROVIDER_KEY);
   let label = (typeof record === 'object' && record && typeof record.display_name === 'string' && record.display_name.trim())
     ? record.display_name.trim()
     : getPreferredModelLabel(modelId, known?.label || modelId);
@@ -505,12 +540,10 @@ export function toKiloCodeModelMeta(record) {
   const intell = normalizedIntell ?? normalizedSWE ?? knownScore ?? known?.intell ?? DEFAULT_DYNAMIC_MODEL_INTELL;
   const isEstimatedScore = !hasScore;
 
-  const ctxRaw = typeof record === 'object' && record
-    ? (record.context_length ?? record.contextLength ?? record.ctx)
-    : null;
-  const ctx = parseKiloCodeContext(ctxRaw) || known?.ctx || DEFAULT_DYNAMIC_MODEL_CTX;
+  const ctxRaw = getReportedContext(record);
+  const { ctx, ctxSource, ctxSourceUrl } = resolveModelContext(ctxRaw, known?.providerKey === KILOCODE_PROVIDER_KEY ? known : null);
 
-  return { modelId, label, intell, isEstimatedScore, ctx, providerKey: KILOCODE_PROVIDER_KEY };
+  return { modelId, label, intell, isEstimatedScore, ctx, ctxSource, ctxSourceUrl, providerKey: KILOCODE_PROVIDER_KEY };
 }
 
 export async function fetchKiloCodeFreeModels(config) {
@@ -590,11 +623,7 @@ export function toOpenAICompatibleDiscoveredModelMeta(record, instanceKey, provi
 
   const scoreLookupId = resolveAliasedModelId(modelId);
   const { base, unprefixed } = canonicalizeModelId(scoreLookupId);
-  const known = knownModelMetaMap.get(scoreLookupId)
-    || knownModelMetaMap.get(base)
-    || knownModelMetaMap.get(unprefixed)
-    || knownModelMetaMap.get(modelId)
-    || null;
+  const known = findKnownModelMeta([scoreLookupId, base, unprefixed, modelId], instanceKey);
   const knownScore = normalizeIntelligenceScore(getScore(scoreLookupId));
   const hasScore = (knownScore != null && knownScore > 0) || (known != null && known.intell != null);
 
@@ -603,10 +632,8 @@ export function toOpenAICompatibleDiscoveredModelMeta(record, instanceKey, provi
     : null;
   const label = getPreferredModelLabel(scoreLookupId, recordLabel || known?.label || formatGenericProviderModelLabel(modelId));
 
-  const ctxRaw = record && typeof record === 'object'
-    ? (record.context_length ?? record.contextLength ?? record.ctx ?? null)
-    : null;
-  const ctx = parseKiloCodeContext(ctxRaw) || known?.ctx || DEFAULT_DYNAMIC_MODEL_CTX;
+  const ctxRaw = getReportedContext(record);
+  const { ctx, ctxSource, ctxSourceUrl } = resolveModelContext(ctxRaw, known?.providerKey === instanceKey ? known : null);
 
   return {
     modelId,
@@ -614,6 +641,8 @@ export function toOpenAICompatibleDiscoveredModelMeta(record, instanceKey, provi
     intell: knownScore ?? known?.intell ?? DEFAULT_DYNAMIC_MODEL_INTELL,
     isEstimatedScore: !hasScore,
     ctx,
+    ctxSource,
+    ctxSourceUrl,
     providerKey: instanceKey,
     providerUrl: providerUrl || undefined,
   };
@@ -666,7 +695,7 @@ export function toOllamaModelMeta(record) {
   const remoteModelId = String(record?.remote_model || '').trim();
   const scoreLookupId = resolveAliasedModelId(remoteModelId || modelId);
   const { base, unprefixed } = canonicalizeModelId(scoreLookupId);
-  const known = knownModelMetaMap.get(scoreLookupId) || knownModelMetaMap.get(base) || knownModelMetaMap.get(unprefixed) || knownModelMetaMap.get(modelId) || null;
+  const known = findKnownModelMeta([scoreLookupId, base, unprefixed, modelId], OLLAMA_PROVIDER_KEY);
   const knownScore = normalizeIntelligenceScore(getScore(scoreLookupId));
   const hasScore = (knownScore != null && knownScore > 0) || (known != null && known.intell != null);
 
@@ -676,17 +705,38 @@ export function toOllamaModelMeta(record) {
     : (known?.label || formatGenericProviderModelLabel(modelId));
   label = getPreferredModelLabel(scoreLookupId, label);
 
+  const runningCtx = parseKiloCodeContext(record?._running?.context_length);
+  const configuredMatch = typeof record?._show?.parameters === 'string'
+    ? record._show.parameters.match(/(?:^|\n)\s*num_ctx\s+(\d+)/i)
+    : null;
+  const configuredCtx = parseKiloCodeContext(configuredMatch?.[1]);
+  const modelInfo = record?._show?.model_info;
+  const maximumRaw = modelInfo && typeof modelInfo === 'object'
+    ? Object.entries(modelInfo).find(([key]) => key.endsWith('.context_length'))?.[1]
+    : null;
+  const maximumCtx = parseKiloCodeContext(maximumRaw);
+  const ctx = runningCtx || configuredCtx || maximumCtx || null;
+  const ctxSource = runningCtx
+    ? 'runtime-allocated'
+    : configuredCtx
+      ? 'provider-reported'
+      : maximumCtx
+        ? 'model-maximum'
+        : null;
+
   return {
     modelId,
     label,
     intell: knownScore ?? known?.intell ?? DEFAULT_DYNAMIC_MODEL_INTELL,
     isEstimatedScore: !hasScore,
-    ctx: getPreferredModelContext(scoreLookupId, known?.ctx || DEFAULT_DYNAMIC_MODEL_CTX),
+    ctx,
+    ctxSource,
+    ctxSourceUrl: ctx ? 'https://docs.ollama.com/api/show' : null,
     providerKey: OLLAMA_PROVIDER_KEY,
   };
 }
 
-function getOllamaModelsUrl(config) {
+function getOllamaApiUrl(config, pathname = '/api/tags') {
   const configuredBaseUrl = getProviderBaseUrl(config, OLLAMA_PROVIDER_KEY) || getDefaultProviderBaseUrl(OLLAMA_PROVIDER_KEY);
   let urlText = configuredBaseUrl.trim();
   if (!/^https?:\/\//i.test(urlText)) {
@@ -695,12 +745,12 @@ function getOllamaModelsUrl(config) {
 
   try {
     const parsed = new URL(urlText);
-    parsed.pathname = '/api/tags';
+    parsed.pathname = pathname;
     parsed.search = '';
     parsed.hash = '';
     return parsed.toString();
   } catch {
-    return 'https://ollama.com/api/tags';
+    return `https://ollama.com${pathname}`;
   }
 }
 
@@ -714,7 +764,7 @@ export async function fetchOllamaModels(config) {
   const ctrl = new AbortController();
   const timeoutId = setTimeout(() => ctrl.abort(), PING_TIMEOUT);
   try {
-    const response = await fetch(getOllamaModelsUrl(config), {
+    const response = await fetch(getOllamaApiUrl(config), {
       method: 'GET',
       headers,
       signal: ctrl.signal,
@@ -725,10 +775,33 @@ export async function fetchOllamaModels(config) {
 
     const payload = await response.json();
     const records = extractOllamaModelRecords(payload);
+    let runningById = new Map();
+    try {
+      const runningResponse = await fetch(getOllamaApiUrl(config, '/api/ps'), { method: 'GET', headers, signal: ctrl.signal });
+      if (runningResponse.ok) {
+        const runningRecords = extractOllamaModelRecords(await runningResponse.json());
+        runningById = new Map(runningRecords.map(item => [String(item.model || item.name || ''), item]));
+      }
+    } catch {}
+
+    const enrichedRecords = await Promise.all(records.map(async record => {
+      const modelId = String(record?.model || record?.name || record?.id || '').trim();
+      let show = null;
+      try {
+        const showResponse = await fetch(getOllamaApiUrl(config, '/api/show'), {
+          method: 'POST',
+          headers: { ...headers, 'Content-Type': 'application/json' },
+          body: JSON.stringify({ model: modelId }),
+          signal: ctrl.signal,
+        });
+        if (showResponse.ok) show = await showResponse.json();
+      } catch {}
+      return { ...record, _show: show, _running: runningById.get(modelId) || null };
+    }));
     const seen = new Set();
     const models = [];
 
-    for (const record of records) {
+    for (const record of enrichedRecords) {
       const model = toOllamaModelMeta(record);
       if (!model || seen.has(model.modelId)) continue;
       seen.add(model.modelId);
@@ -750,7 +823,7 @@ export function toOpenCodeModelMeta(record) {
 
   const scoreModelId = meta?.scoreId || modelId;
   const { base, unprefixed } = canonicalizeModelId(scoreModelId);
-  const known = knownModelMetaMap.get(scoreModelId) || knownModelMetaMap.get(base) || knownModelMetaMap.get(unprefixed) || knownModelMetaMap.get(modelId) || null;
+  const known = findKnownModelMeta([scoreModelId, base, unprefixed, modelId], OPENCODE_PROVIDER_KEY);
   const knownScore = normalizeIntelligenceScore(getScore(scoreModelId));
   const hasScore = (knownScore != null && knownScore > 0) || (known != null && known.intell != null);
 
@@ -759,7 +832,9 @@ export function toOpenCodeModelMeta(record) {
     label: getPreferredModelLabel(modelId, meta?.label || known?.label || formatGenericProviderModelLabel(modelId)),
     intell: knownScore ?? known?.intell ?? DEFAULT_DYNAMIC_MODEL_INTELL,
     isEstimatedScore: !hasScore,
-    ctx: meta?.ctx || getPreferredModelContext(scoreModelId, known?.ctx || DEFAULT_DYNAMIC_MODEL_CTX),
+    ctx: meta?.ctx || (known?.providerKey === OPENCODE_PROVIDER_KEY ? getPreferredModelContext(scoreModelId, known.ctx) : null),
+    ctxSource: (meta?.ctx || (known?.providerKey === OPENCODE_PROVIDER_KEY && known.ctx)) ? 'curated' : null,
+    ctxSourceUrl: known?.providerKey === OPENCODE_PROVIDER_KEY ? known.ctxSourceUrl : null,
     providerKey: OPENCODE_PROVIDER_KEY,
   };
 }
@@ -807,7 +882,7 @@ export function toOpenRouterModelMeta(record) {
   if (isExcludedDynamicModelId(modelId)) return null;
 
   const { base, unprefixed } = canonicalizeModelId(modelId);
-  const known = knownModelMetaMap.get(base) || knownModelMetaMap.get(unprefixed) || null;
+  const known = findKnownModelMeta([base, unprefixed], OPENROUTER_PROVIDER_KEY);
   let label = (record && typeof record.name === 'string' && record.name.trim())
     ? record.name.trim()
     : (known?.label || modelId);
@@ -836,10 +911,10 @@ export function toOpenRouterModelMeta(record) {
   const intell = knownScore ?? known?.intell ?? DEFAULT_DYNAMIC_MODEL_INTELL;
   const isEstimatedScore = !hasScore;
 
-  const ctxRaw = record?.context_length ?? record?.contextLength ?? record?.ctx;
-  const ctx = parseKiloCodeContext(ctxRaw) || known?.ctx || DEFAULT_DYNAMIC_MODEL_CTX;
+  const ctxRaw = getReportedContext(record);
+  const { ctx, ctxSource, ctxSourceUrl } = resolveModelContext(ctxRaw, known?.providerKey === OPENROUTER_PROVIDER_KEY ? known : null);
 
-  return { modelId, label, intell, isEstimatedScore, ctx, providerKey: OPENROUTER_PROVIDER_KEY };
+  return { modelId, label, intell, isEstimatedScore, ctx, ctxSource, ctxSourceUrl, providerKey: OPENROUTER_PROVIDER_KEY };
 }
 
 export async function fetchOpenRouterFreeModels(config) {
@@ -2297,7 +2372,7 @@ export async function runServer(config, port, enableLog = true, bannedModels = [
 
   let autoUpdateInProgress = false;
 
-  const toResultRow = ([modelId, label, intell, ctx, providerKey], index, isEstimatedScoreOverride = null) => {
+  const toResultRow = ([modelId, label, intell, ctx, providerKey, ctxSource = null, ctxSourceUrl = null], index, isEstimatedScoreOverride = null) => {
     const hasScore = intell != null;
     return {
       idx: index + 1,
@@ -2308,6 +2383,8 @@ export async function runServer(config, port, enableLog = true, bannedModels = [
       qualitySource: hasScore ? 'local-fallback' : 'default-fallback',
       qualityDetail: hasScore ? 'scores.js offline fallback' : 'no catalog or local score',
       ctx,
+      ctxSource,
+      ctxSourceUrl,
       providerKey,
       builtInTags: getBuiltInModelTags(modelId),
       userTags: [],
@@ -2386,6 +2463,8 @@ export async function runServer(config, port, enableLog = true, bannedModels = [
         existing.intell = model.intell;
         existing.isEstimatedScore = model.isEstimatedScore;
         existing.ctx = model.ctx;
+        existing.ctxSource = model.ctxSource;
+        existing.ctxSourceUrl = model.ctxSourceUrl;
         results.push(existing);
       } else {
         results.push(toResultRow([
@@ -2394,6 +2473,8 @@ export async function runServer(config, port, enableLog = true, bannedModels = [
           model.intell,
           model.ctx,
           providerKey,
+          model.ctxSource,
+          model.ctxSourceUrl,
         ], results.length, model.isEstimatedScore));
       }
     }
@@ -2417,6 +2498,8 @@ export async function runServer(config, port, enableLog = true, bannedModels = [
       row.intell = model.intell;
       row.isEstimatedScore = model.isEstimatedScore;
       row.ctx = model.ctx;
+      row.ctxSource = model.ctxSource;
+      row.ctxSourceUrl = model.ctxSourceUrl;
       row.providerUrl = model.providerUrl || row.providerUrl;
       return row;
     };
@@ -2433,6 +2516,8 @@ export async function runServer(config, port, enableLog = true, bannedModels = [
           model.intell,
           model.ctx,
           providerKey,
+          model.ctxSource,
+          model.ctxSourceUrl,
         ], results.length, model.isEstimatedScore));
       }
     }
@@ -2555,6 +2640,8 @@ export async function runServer(config, port, enableLog = true, bannedModels = [
             intell: r.intell,
             isEstimatedScore: r.isEstimatedScore,
             ctx: r.ctx,
+            ctxSource: r.ctxSource,
+            ctxSourceUrl: r.ctxSourceUrl,
             providerKey: ep.instanceKey,
             providerUrl: r.providerUrl,
           }));
@@ -2684,6 +2771,8 @@ export async function runServer(config, port, enableLog = true, bannedModels = [
         intell: r.intell,
         isEstimatedScore: r.isEstimatedScore,
         ctx: r.ctx,
+        ctxSource: r.ctxSource,
+        ctxSourceUrl: r.ctxSourceUrl,
         providerKey: r.providerKey,
       }));
   };
@@ -3344,6 +3433,8 @@ export async function runServer(config, port, enableLog = true, bannedModels = [
             modelId: ranked.modelId,
             label: ranked.label,
             ctx: ranked.ctx,
+            ctxSource: ranked.ctxSource,
+            ctxSourceUrl: ranked.ctxSourceUrl,
             intell: ranked.intell,
             isEstimatedScore: ranked.isEstimatedScore === true,
             qualitySource: ranked.qualitySource,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -364,21 +364,16 @@ const TAG_REQUEST_PREFIX = 'tag:'
  */
 export function parseContextSize(value) {
   if (value == null) return null
-  if (typeof value === 'number') return Number.isFinite(value) && value >= 0 ? Math.round(value) : null
+  if (typeof value === 'number') return Number.isFinite(value) && value > 0 ? Math.round(value) : null
 
   const str = String(value).trim().toLowerCase()
   if (!str || str === '—') return null
-
-  if (str.endsWith('m')) {
-    const num = parseFloat(str)
-    return Number.isFinite(num) ? Math.round(num * 1_000_000) : null
-  }
-  if (str.endsWith('k')) {
-    const num = parseFloat(str)
-    return Number.isFinite(num) ? Math.round(num * 1_000) : null
-  }
-  const num = parseFloat(str)
-  return Number.isFinite(num) ? Math.round(num) : null
+  const match = str.match(/^(\d+(?:\.\d+)?)\s*([km])?$/)
+  if (!match) return null
+  const num = Number(match[1])
+  if (!Number.isFinite(num) || num <= 0) return null
+  const multiplier = match[2] === 'm' ? 1_000_000 : match[2] === 'k' ? 1_000 : 1
+  return Math.round(num * multiplier)
 }
 
 /**
@@ -415,6 +410,7 @@ function parseTagRequest(rest) {
 
 function matchesMinCtx(result, minCtx) {
   if (minCtx == null) return true
+  if (result.ctxSource === 'model-maximum') return false
   const resultCtx = parseContextSize(result.ctx)
   return resultCtx != null && resultCtx >= minCtx
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -357,16 +357,90 @@ export function buildModelGroups(results, canonicalizeFn) {
 
 const TAG_REQUEST_PREFIX = 'tag:'
 
+/**
+ * Parses a human-readable context-size string ("128k", "1m", "32000") into a raw token count.
+ * Returns null for anything unparseable/empty. Used by the `tag:<name>+min_ctx:<n>` request
+ * syntax to filter out models whose context window can't fit the caller's stated requirement.
+ */
+export function parseContextSize(value) {
+  if (value == null) return null
+  if (typeof value === 'number') return Number.isFinite(value) && value >= 0 ? Math.round(value) : null
+
+  const str = String(value).trim().toLowerCase()
+  if (!str || str === '—') return null
+
+  if (str.endsWith('m')) {
+    const num = parseFloat(str)
+    return Number.isFinite(num) ? Math.round(num * 1_000_000) : null
+  }
+  if (str.endsWith('k')) {
+    const num = parseFloat(str)
+    return Number.isFinite(num) ? Math.round(num * 1_000) : null
+  }
+  const num = parseFloat(str)
+  return Number.isFinite(num) ? Math.round(num) : null
+}
+
+/**
+ * Parses `+`-delimited `key:value` modifiers, e.g. the `min_ctx:32000` in
+ * `tag:general+min_ctx:32000` or `auto-fastest+min_ctx:128k`. Unknown modifier keys are
+ * ignored rather than rejected, so new modifiers can be added later without breaking older
+ * callers or requiring a new reserved prefix per modifier.
+ */
+function parseModifiers(parts) {
+  let minCtx = null
+  for (const part of parts) {
+    const sepIdx = part.indexOf(':')
+    if (sepIdx === -1) continue
+    const key = part.slice(0, sepIdx).trim()
+    const value = part.slice(sepIdx + 1).trim()
+    if (key === 'min_ctx' && value) {
+      const parsed = parseContextSize(value)
+      if (parsed != null) minCtx = parsed
+    }
+  }
+  return { minCtx }
+}
+
+/**
+ * Parses a `tag:<name>[+modifier...]` request. The tag name is always the first
+ * `+`-delimited segment; anything after that is passed to parseModifiers().
+ */
+function parseTagRequest(rest) {
+  const parts = String(rest || '').split('+').map(s => s.trim()).filter(Boolean)
+  const tag = parts[0] || ''
+  const { minCtx } = parseModifiers(parts.slice(1))
+  return { tag, minCtx }
+}
+
+function matchesMinCtx(result, minCtx) {
+  if (minCtx == null) return true
+  const resultCtx = parseContextSize(result.ctx)
+  return resultCtx != null && resultCtx >= minCtx
+}
+
 export function filterModelsByRequested(results, requestedModel, canonicalizeFn) {
-  if (!requestedModel || requestedModel === 'auto-fastest') return results
+  if (!requestedModel) return results
 
   const requested = normalizeModelAlias(requestedModel)
-  if (requested.startsWith('tag:')) {
-    const tag = requested.slice(4).trim()
+  if (requested === 'auto-fastest') return results
+
+  // auto-fastest+min_ctx:<n>: same QoS-driven "fastest" selection as auto-fastest, but
+  // restricted to models that can actually fit a prompt of the caller's stated size --
+  // see https://github.com/ellipticmarketing/modelrelay/issues/42.
+  if (requested.startsWith('auto-fastest+')) {
+    const parts = requested.slice('auto-fastest+'.length).split('+').map(s => s.trim()).filter(Boolean)
+    const { minCtx } = parseModifiers(parts)
+    if (minCtx == null) return results
+    return results.filter(result => matchesMinCtx(result, minCtx))
+  }
+
+  if (requested.startsWith(TAG_REQUEST_PREFIX)) {
+    const { tag, minCtx } = parseTagRequest(requested.slice(TAG_REQUEST_PREFIX.length))
     if (!tag) return []
     return results.filter(result => {
       const tags = [...getBuiltInModelTags(result.modelId), ...(Array.isArray(result.tags) ? result.tags : [])]
-      return tags.includes(tag)
+      return tags.includes(tag) && matchesMinCtx(result, minCtx)
     })
   }
   const providerQualifiedMatches = results.filter(r => getRoutingModelKey(r) === requested)

--- a/public/index.html
+++ b/public/index.html
@@ -3542,12 +3542,27 @@
       return `${Math.round(model.intell * 100)} (${getQualitySourceDisplay(model.qualitySource).label})`;
     }
 
+    function formatContextDisplay(value) {
+      if (value == null || value === '' || value === '—') return 'N/A';
+      const match = String(value).trim().toLowerCase().match(/^(\d+(?:\.\d+)?)\s*([km])?$/);
+      if (!match) return String(value);
+      const number = Number(match[1]);
+      const tokens = number * (match[2] === 'm' ? 1_000_000 : match[2] === 'k' ? 1_000 : 1);
+      if (!Number.isFinite(tokens) || tokens <= 0) return 'N/A';
+      if (tokens >= 1_000_000) {
+        const millions = Math.round(tokens / 100_000) / 10;
+        return `${millions}M`;
+      }
+      if (tokens >= 1_000) return `${Math.round(tokens / 1_000)}K`;
+      return String(Math.round(tokens));
+    }
+
     function renderProviderSyncSuccess(providerName, models) {
       const count = models.length;
       const items = models
         .slice()
         .sort((a, b) => (a.label || a.modelId || '').localeCompare(b.label || b.modelId || ''))
-        .map(model => `<li><b>${escapeHtml(model.label || model.modelId)}</b><br><span style="color:var(--text-muted);">${escapeHtml(model.modelId)} • ${escapeHtml(model.ctx || '128k')} • Coding ${escapeHtml(formatSyncScore(model))}</span></li>`)
+        .map(model => `<li><b>${escapeHtml(model.label || model.modelId)}</b><br><span style="color:var(--text-muted);">${escapeHtml(model.modelId)} • ${escapeHtml(formatContextDisplay(model.ctx))} • Coding ${escapeHtml(formatSyncScore(model))}</span></li>`)
         .join('');
 
       openProviderSyncModal(
@@ -5386,7 +5401,7 @@
           </div>
           <div style="background: var(--chat-bg); padding: 16px; border-radius: 12px; border: 1px solid var(--border);">
             <div style="font-size: 0.75rem; color: var(--text-muted); margin-bottom: 4px;">Context</div>
-            <div style="font-weight: 700;">${m.ctx || 'N/A'}</div>
+            <div style="font-weight: 700;">${formatContextDisplay(m.ctx)}</div>
           </div>
         </div>
         <div class="tag-workbench">

--- a/sources.js
+++ b/sources.js
@@ -215,6 +215,7 @@ export const sources = {
   "nvidia": {
     "name": "NIM",
     "url": "https://integrate.api.nvidia.com/v1/chat/completions",
+    "contextUrl": "https://build.nvidia.com/models",
     "discoverable": true,
     "models": [
       ["z-ai/glm-5.2", "GLM 5.2", "200k"],
@@ -271,11 +272,12 @@ export const sources = {
   "groq": {
     "name": "Groq",
     "url": "https://api.groq.com/openai/v1/chat/completions",
+    "contextUrl": "https://console.groq.com/docs/models",
     "discoverable": true,
     "models": [
       ["llama-3.3-70b-versatile", "Llama 3.3 70B", "128k"],
-      ["meta-llama/llama-4-scout-17b-16e-preview", "Llama 4 Scout", "10M"],
-      ["meta-llama/llama-4-maverick-17b-128e-preview", "Llama 4 Maverick", "1M"],
+      ["meta-llama/llama-4-scout-17b-16e-preview", "Llama 4 Scout", "128k"],
+      ["meta-llama/llama-4-maverick-17b-128e-preview", "Llama 4 Maverick", "128k"],
       ["deepseek-r1-distill-llama-70b", "R1 Distill 70B", "128k"],
       ["qwen-qwq-32b", "QwQ 32B", "131k"],
       ["moonshotai/kimi-k2-instruct", "Kimi K2 Instruct", "131k"],
@@ -288,6 +290,7 @@ export const sources = {
   "cerebras": {
     "name": "Cerebras",
     "url": "https://api.cerebras.ai/v1/chat/completions",
+    "contextUrl": "https://api.cerebras.ai/public/v1/models?format=openrouter",
     "discoverable": true,
     "models": [
       ["zai-glm-4.7", "GLM 4.7", "128k"],
@@ -314,6 +317,7 @@ export const sources = {
   "openrouter": {
     "name": "OpenRouter",
     "url": "https://openrouter.ai/api/v1/chat/completions",
+    "contextUrl": "https://openrouter.ai/api/v1/models",
     "models": [
       ["qwen/qwen3-coder:free", "Qwen3 Coder", "256k"],
       ["xiaomi/mimo-v2-pro:free", "MiMo V2 Omni Pro", "1M"],
@@ -322,8 +326,8 @@ export const sources = {
       ["deepseek/deepseek-r1-0528:free", "DeepSeek R1 0528", "128k"],
       ["qwen/qwen3-next-80b-a3b-instruct:free", "Qwen3 80B Instruct", "128k"],
       ["openai/gpt-oss-120b:free", "GPT OSS 120B", "128k"],
-      ["openai/gpt-oss-20b:free", "GPT OSS 20B", "128k"],
-      ["nvidia/nemotron-3-nano-30b-a3b:free", "Nemotron Nano 30B", "128k"],
+      ["openai/gpt-oss-20b:free", "GPT OSS 20B", "131072"],
+      ["nvidia/nemotron-3-nano-30b-a3b:free", "Nemotron Nano 30B", "256k"],
       ["meta-llama/llama-3.3-70b-instruct:free", "Llama 3.3 70B", "128k"],
       ["minimax/minimax-m2.5:free", "MiniMax M2.5", "128k"],
       ["corethink:free", "CoreThink", "128k"],
@@ -333,6 +337,7 @@ export const sources = {
   "codestral": {
     "name": "Codestral",
     "url": "https://codestral.mistral.ai/v1/chat/completions",
+    "contextUrl": "https://docs.mistral.ai/getting-started/models/models_overview/",
     "models": [
       ["codestral-latest", "Codestral", "256k"]
     ]
@@ -340,20 +345,22 @@ export const sources = {
   "scaleway": {
     "name": "Scaleway",
     "url": "https://api.scaleway.ai/v1/chat/completions",
+    "contextUrl": "https://www.scaleway.com/en/docs/generative-apis/reference-content/supported-models/",
     "discoverable": true,
     "models": [
-      ["devstral-2-123b-instruct-2512", "Devstral 2 123B", "256k"],
-      ["qwen3-235b-a22b-instruct-2507", "Qwen3 235B", "128k"],
+      ["devstral-2-123b-instruct-2512", "Devstral 2 123B", "200k"],
+      ["qwen3-235b-a22b-instruct-2507", "Qwen3 235B", "250k"],
       ["gpt-oss-120b", "GPT OSS 120B", "128k"],
-      ["qwen3-coder-30b-a3b-instruct", "Qwen3 Coder 30B", "32k"],
-      ["llama-3.3-70b-instruct", "Llama 3.3 70B", "128k"],
-      ["deepseek-r1-distill-llama-70b", "R1 Distill 70B", "128k"],
+      ["qwen3-coder-30b-a3b-instruct", "Qwen3 Coder 30B", "128k"],
+      ["llama-3.3-70b-instruct", "Llama 3.3 70B", "100k"],
+      ["deepseek-r1-distill-llama-70b", "R1 Distill 70B", "16k"],
       ["mistral-small-3.2-24b-instruct-2506", "Mistral Small 3.2", "128k"]
     ]
   },
   "kilocode": {
     "name": "KiloCode",
     "url": "https://api.kilo.ai/api/gateway/chat/completions",
+    "contextUrl": "https://api.kilo.ai/api/gateway/models",
     "models": [
       ["arcee-ai/trinity-large-preview", "Trinity Large", "128k"]
     ]
@@ -361,6 +368,7 @@ export const sources = {
   "kiro": {
     "name": "Kiro",
     "url": "https://codewhisperer.us-east-1.amazonaws.com/generateAssistantResponse",
+    "contextUrl": "https://kiro.dev/docs/cli/reference/models/",
     "models": [
       ["claude-sonnet-4.5", "Claude Sonnet 4.5", "200k"],
       ["claude-haiku-4.5", "Claude Haiku 4.5", "200k"]
@@ -369,6 +377,7 @@ export const sources = {
   "googleai": {
     "name": "Google AI",
     "url": "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions",
+    "contextUrl": "https://ai.google.dev/gemma/docs/core/model_card_3",
     "discoverable": true,
     "models": [
       ["gemma-3-27b-it", "Gemma 3 27B", "128k"],
@@ -384,7 +393,7 @@ function buildModels() {
     for (const m of provider.models) {
       const [modelId, label, ctx] = m
       const intell = getScore(modelId)
-      result.push([modelId, label, intell, ctx, providerKey])
+      result.push([modelId, label, intell, ctx, providerKey, ctx ? 'curated' : null, ctx ? provider.contextUrl || null : null])
     }
   }
   return result

--- a/test/discovery.js
+++ b/test/discovery.js
@@ -28,7 +28,8 @@ describe('OpenRouter model discovery', () => {
     assert.ok(freeMeta)
     assert.equal(freeMeta.modelId, 'google/gemma-7b-it:free')
     assert.equal(freeMeta.label, 'Gemma 7B IT')
-    assert.equal(freeMeta.ctx, '8k')
+    assert.equal(freeMeta.ctx, '8192')
+    assert.equal(freeMeta.ctxSource, 'provider-reported')
     assert.equal(freeMeta.providerKey, 'openrouter')
 
     const paidMeta = toOpenRouterModelMeta(paidRecord)
@@ -51,6 +52,7 @@ describe('OpenRouter model discovery', () => {
 
   it('handles missing or malformed fields in records', () => {
     assert.equal(toOpenRouterModelMeta({ id: 'only-id:free' }).label, 'only-id:free')
-    assert.equal(toOpenRouterModelMeta({ id: 'only-id:free' }).ctx, '128k') // default
+    assert.equal(toOpenRouterModelMeta({ id: 'only-id:free' }).ctx, null)
+    assert.equal(toOpenRouterModelMeta({ id: 'only-id:free' }).ctxSource, null)
   })
 })

--- a/test/test.js
+++ b/test/test.js
@@ -19,6 +19,7 @@ import {
   filterModelsByRequested,
   isRetryableProxyStatus,
   computeFailedRefreshRetryAt,
+  parseContextSize,
   parseArgs,
   parseOpenRouterKeyRateLimit,
   selectNextApiKeyFromPool,
@@ -987,6 +988,75 @@ describe('user-defined model tags', () => {
     assert.deepEqual(filterModelsByRequested(results, 'tag:'), [])
   })
 
+  it('filters tag requests by a min_ctx modifier', () => {
+    const results = [
+      mockResult({ modelId: 'small', tags: ['general'], ctx: '8k' }),
+      mockResult({ modelId: 'medium', tags: ['general'], ctx: '32k' }),
+      mockResult({ modelId: 'large', tags: ['general'], ctx: '1m' }),
+      mockResult({ modelId: 'no-ctx', tags: ['general'], ctx: null }),
+      mockResult({ modelId: 'wrong-tag', tags: ['coding'], ctx: '1m' }),
+    ]
+
+    assert.deepEqual(
+      filterModelsByRequested(results, 'tag:general+min_ctx:32000').map(m => m.modelId),
+      ['medium', 'large'],
+    )
+    // Exact boundary: a 32k model satisfies a 32000-token floor.
+    assert.deepEqual(
+      filterModelsByRequested(results, 'tag:general+min_ctx:32001').map(m => m.modelId),
+      ['large'],
+    )
+    // Shorthand k/m suffixes on the modifier value itself.
+    assert.deepEqual(
+      filterModelsByRequested(results, 'tag:general+min_ctx:1m').map(m => m.modelId),
+      ['large'],
+    )
+    // No modifier -- unchanged plain tag behavior, unparseable/missing ctx included.
+    assert.deepEqual(
+      filterModelsByRequested(results, 'tag:general').map(m => m.modelId),
+      ['small', 'medium', 'large', 'no-ctx'],
+    )
+  })
+
+  it('ignores unknown or malformed tag modifiers instead of rejecting the request', () => {
+    const results = [mockResult({ modelId: 'one', tags: ['general'], ctx: '128k' })]
+    assert.deepEqual(
+      filterModelsByRequested(results, 'tag:general+unknown_modifier:whatever').map(m => m.modelId),
+      ['one'],
+    )
+    assert.deepEqual(
+      filterModelsByRequested(results, 'tag:general+min_ctx:not-a-number').map(m => m.modelId),
+      ['one'],
+    )
+    assert.deepEqual(
+      filterModelsByRequested(results, 'tag:general+').map(m => m.modelId),
+      ['one'],
+    )
+  })
+
+  it('filters auto-fastest by min_ctx regardless of capability tags (issue #42)', () => {
+    const results = [
+      mockResult({ modelId: 'small', tags: ['general'], ctx: '8k' }),
+      mockResult({ modelId: 'medium', tags: ['coding'], ctx: '128k' }),
+      mockResult({ modelId: 'large', ctx: '1m' }), // no tags at all -- still eligible
+    ]
+
+    assert.deepEqual(
+      filterModelsByRequested(results, 'auto-fastest+min_ctx:128k').map(m => m.modelId),
+      ['medium', 'large'],
+    )
+    // Plain auto-fastest is untouched -- still returns everything, unfiltered.
+    assert.deepEqual(
+      filterModelsByRequested(results, 'auto-fastest').map(m => m.modelId),
+      ['small', 'medium', 'large'],
+    )
+    // A malformed/unknown modifier falls back to plain auto-fastest behavior.
+    assert.deepEqual(
+      filterModelsByRequested(results, 'auto-fastest+bogus:xyz').map(m => m.modelId),
+      ['small', 'medium', 'large'],
+    )
+  })
+
   it('normalizes persisted model tags safely', () => {
     const normalized = normalizeConfigShape({
       modelTags: {
@@ -1639,6 +1709,30 @@ describe('computeFailedRefreshRetryAt', () => {
     const now = Date.now()
     const stampedAt = computeFailedRefreshRetryAt(now, 30 * 60_000, 2 * 60_000)
     assert.ok(stampedAt < now)
+  })
+})
+
+describe('parseContextSize', () => {
+  it('parses k and m suffixes into raw token counts', () => {
+    assert.equal(parseContextSize('128k'), 128_000)
+    assert.equal(parseContextSize('1m'), 1_000_000)
+    assert.equal(parseContextSize('1M'), 1_000_000)
+    assert.equal(parseContextSize('10M'), 10_000_000)
+    assert.equal(parseContextSize('0.5m'), 500_000)
+  })
+
+  it('parses plain numbers, string or numeric', () => {
+    assert.equal(parseContextSize('32000'), 32_000)
+    assert.equal(parseContextSize(32000), 32_000)
+  })
+
+  it('returns null for unparseable, empty, or negative input', () => {
+    assert.equal(parseContextSize(null), null)
+    assert.equal(parseContextSize(undefined), null)
+    assert.equal(parseContextSize(''), null)
+    assert.equal(parseContextSize('—'), null)
+    assert.equal(parseContextSize('not-a-number'), null)
+    assert.equal(parseContextSize(-5), null)
   })
 })
 

--- a/test/test.js
+++ b/test/test.js
@@ -230,13 +230,15 @@ describe('sources data integrity', () => {
     }
   })
 
-  it('flat MODELS tuples have 5 fields', () => {
+  it('flat MODELS tuples include context provenance', () => {
     for (const model of MODELS) {
       assert.ok(Array.isArray(model))
-      assert.equal(model.length, 5)
+      assert.equal(model.length, 7)
       assert.equal(typeof model[0], 'string')
       assert.equal(typeof model[1], 'string')
       assert.equal(typeof model[4], 'string')
+      assert.equal(model[5], 'curated')
+      assert.equal(typeof model[6], 'string')
     }
   })
 
@@ -993,6 +995,7 @@ describe('user-defined model tags', () => {
       mockResult({ modelId: 'small', tags: ['general'], ctx: '8k' }),
       mockResult({ modelId: 'medium', tags: ['general'], ctx: '32k' }),
       mockResult({ modelId: 'large', tags: ['general'], ctx: '1m' }),
+      mockResult({ modelId: 'maximum-only', tags: ['general'], ctx: '1m', ctxSource: 'model-maximum' }),
       mockResult({ modelId: 'no-ctx', tags: ['general'], ctx: null }),
       mockResult({ modelId: 'wrong-tag', tags: ['coding'], ctx: '1m' }),
     ]
@@ -1014,7 +1017,7 @@ describe('user-defined model tags', () => {
     // No modifier -- unchanged plain tag behavior, unparseable/missing ctx included.
     assert.deepEqual(
       filterModelsByRequested(results, 'tag:general').map(m => m.modelId),
-      ['small', 'medium', 'large', 'no-ctx'],
+      ['small', 'medium', 'large', 'maximum-only', 'no-ctx'],
     )
   })
 
@@ -1256,7 +1259,7 @@ describe('dynamic model score resolution', () => {
     assert.equal(model.isEstimatedScore, false)
   })
 
-  it('uses researched Kimi K2.6 score and context for Ollama discovery', () => {
+  it('does not apply another provider context to Ollama discovery', () => {
     const model = toOllamaModelMeta({
       name: 'kimi-k2.6',
       model: 'kimi-k2.6',
@@ -1266,7 +1269,31 @@ describe('dynamic model score resolution', () => {
     assert.equal(model.label, 'Kimi K2.6')
     assert.equal(model.intell, 0.802)
     assert.equal(model.isEstimatedScore, false)
-    assert.equal(model.ctx, '262k')
+    assert.equal(model.ctx, null)
+    assert.equal(model.ctxSource, null)
+  })
+
+  it('uses the allocated Ollama context before the model maximum', () => {
+    const model = toOllamaModelMeta({
+      name: 'gemma3',
+      model: 'gemma3',
+      _running: { context_length: 4096 },
+      _show: { model_info: { 'gemma3.context_length': 131072 } },
+    })
+
+    assert.equal(model.ctx, '4096')
+    assert.equal(model.ctxSource, 'runtime-allocated')
+  })
+
+  it('labels an unallocated Ollama model limit as a model maximum', () => {
+    const model = toOllamaModelMeta({
+      name: 'gemma3',
+      model: 'gemma3',
+      _show: { model_info: { 'gemma3.context_length': 131072 } },
+    })
+
+    assert.equal(model.ctx, '131072')
+    assert.equal(model.ctxSource, 'model-maximum')
   })
 
   it('keeps MiniMax M-series SWE scores monotonic as versions increase', () => {
@@ -1430,7 +1457,7 @@ describe('dynamic model score resolution', () => {
     assert.equal(model.isEstimatedScore, false)
   })
 
-  it('normalizes Ling 2.6 Flash free aliases and keeps provider context metadata', () => {
+  it('does not copy Ling 2.6 context metadata between providers', () => {
     assert.equal(resolveAliasedModelId('ling-2.6-flash-free'), 'inclusionai/ling-2.6-flash')
     assert.equal(resolveAliasedModelId('inclusionai/ling-2.6-flash:free'), 'inclusionai/ling-2.6-flash')
     assert.equal(getScore('ling-2.6-flash-free'), 0.771)
@@ -1441,7 +1468,8 @@ describe('dynamic model score resolution', () => {
 
     assert.ok(model)
     assert.equal(model.label, 'Ling 2.6 Flash')
-    assert.equal(model.ctx, '262k')
+    assert.equal(model.ctx, null)
+    assert.equal(model.ctxSource, null)
     assert.equal(model.intell, 0.771)
     assert.equal(model.isEstimatedScore, false)
 
@@ -1453,6 +1481,8 @@ describe('dynamic model score resolution', () => {
 
     assert.ok(openRouterModel)
     assert.equal(openRouterModel.intell, 0.771)
+    assert.equal(openRouterModel.ctx, '262144')
+    assert.equal(openRouterModel.ctxSource, 'provider-reported')
     assert.equal(openRouterModel.isEstimatedScore, false)
   })
 
@@ -1733,6 +1763,11 @@ describe('parseContextSize', () => {
     assert.equal(parseContextSize('—'), null)
     assert.equal(parseContextSize('not-a-number'), null)
     assert.equal(parseContextSize(-5), null)
+    assert.equal(parseContextSize('-5'), null)
+    assert.equal(parseContextSize('-5k'), null)
+    assert.equal(parseContextSize('128garbage'), null)
+    assert.equal(parseContextSize('1.2.3m'), null)
+    assert.equal(parseContextSize(0), null)
   })
 })
 
@@ -2268,6 +2303,12 @@ describe('package and entrypoint sanity', () => {
     assert.ok(dashboardContent.includes('Use <code>tag:name</code>'))
   })
 
+  it('formats exact context sizes for display without changing routing data', () => {
+    assert.match(dashboardContent, /function formatContextDisplay\(value\)/)
+    assert.match(dashboardContent, /Math\.round\(tokens \/ 1_000\).*K/)
+    assert.match(dashboardContent, /formatContextDisplay\(m\.ctx\)/)
+  })
+
   it('includes working provider key reveal and copy controls', () => {
     assert.ok(dashboardContent.includes('toggleProviderKeyVisibility'))
     assert.ok(dashboardContent.includes('getConfiguredProviderKey'))
@@ -2684,8 +2725,8 @@ describe('OpenAI-compatible model discovery', () => {
     assert.equal(meta.label, 'Qwen2.5 Coder 7B')
     assert.equal(meta.providerKey, 'openai-compatible:my-vllm')
     assert.equal(meta.providerUrl, 'https://host/v1/chat/completions')
-    // 32768 → "33k" via the shared parser
-    assert.equal(meta.ctx, '33k')
+    assert.equal(meta.ctx, '32768')
+    assert.equal(meta.ctxSource, 'provider-reported')
   })
 
   it('falls back to a synthesized label when the record has none', () => {


### PR DESCRIPTION
## Summary
- Use provider-specific context data for model routing.
- Add `min_ctx` modifiers for tag and `auto-fastest` requests.
- Track context data sources in model metadata and the dashboard.
- Add provider context documentation and source links.
- Expand discovery and routing tests.

## Testing
- `pnpm test`