### PR TITLE
Fix Cerebras zai-glm-4.7 context window: catalog says 128k, real limit is 8192

### DIFF
--- a/sources.js
+++ b/sources.js
@@ -293,7 +293,16 @@ export const sources = {
     "contextUrl": "https://api.cerebras.ai/public/v1/models?format=openrouter",
     "discoverable": true,
     "models": [
-      ["zai-glm-4.7", "GLM 4.7", "128k"],
+      // Cerebras' own /v1/models?format=openrouter reports context_length: 131072 for this
+      // model, and their docs claim 64k on the free tier -- but the live account this project
+      // actually uses (likely on a more restrictive "Free Trial" tier, not full "Free") gets
+      // hard-rejected by the real API at 8192 tokens: "Please reduce the length of the messages
+      // or completion. Current length is 23592 while limit is 8192" (confirmed live 2026-08-07,
+      // this is what a real openclaw-sandbox request hit via auto-fastest+min_ctx:32000 -- the
+      // min_ctx filter can only work if this catalog value reflects what actually gets accepted,
+      // not the model's advertised maximum). If the account tier ever changes, re-verify before
+      // raising this.
+      ["zai-glm-4.7", "GLM 4.7", "8192"],
       ["llama3.1-8b", "Llama 3.1 8B", "128k"],
       ["qwen-3-235b-a22b-instruct-2507", "Qwen3 235B", "128k"],
       ["gpt-oss-120b", "GPT OSS 120B", "128k"]


### PR DESCRIPTION
## Summary
- Cerebras' own `/v1/models?format=openrouter` reports `context_length: 131072` for `zai-glm-4.7`, and their docs page describes 64k on the free tier — but real requests through a live account hard-fail well below either number.
- Confirmed live: a real request via `auto-fastest+min_ctx:32000` (#72) landed on this model and got rejected with `"Please reduce the length of the messages or completion. Current length is 23592 while limit is 8192"`.
- The `min_ctx` filter can only work if the catalog value reflects what the API actually accepts, not the model's advertised maximum. Likely a more restrictive "Free Trial" tier vs. a fuller "Free" tier that Cerebras doesn't surface in the model list itself.
- Since this project is specifically about optimizing free-model usage, the free-tier-accessible limit is the value that matters for most deployments relying on this catalog.

## Test plan
- [x] `npm test` — all 218 tests pass, unaffected by this data-only change
- [x] Verified live: after applying this fix, a ~15k-token request that previously failed at the old 8192 real limit now correctly gets filtered away from `zai-glm-4.7` by `min_ctx:32000` and routes to a different model instead, succeeding end-to-end